### PR TITLE
U-Stealth.CLI is now Native AOT and trimmed

### DIFF
--- a/UStealth.DriveHelper/Program.cs
+++ b/UStealth.DriveHelper/Program.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 using System.Text.Json;
-using System.Management;
+using WmiLight;
 using System.Collections.Generic;
 using Spectre.Console;
 using System.Text.Json.Serialization;
@@ -21,6 +21,7 @@ namespace UStealth.DriveHelper
             // Elevation check at the very beginning of interactive mode
             if (args.Length < 1)
             {
+#if !DEBUG
                 if (!IsRunningAsAdministrator())
                 {
                     AnsiConsole.MarkupLine("[yellow]This tool requires administrator privileges. Relaunching with elevation...[/]");
@@ -40,6 +41,7 @@ namespace UStealth.DriveHelper
                     }
                     return 123; // Exit current process
                 }
+#endif
 
                 while (true)
                 {
@@ -94,8 +96,9 @@ namespace UStealth.DriveHelper
                             try
                             {
                                 string sysDrive = Environment.GetFolderPath(Environment.SpecialFolder.System).Substring(0, 2);
-                                var searcher = new ManagementObjectSearcher("SELECT * FROM Win32_DiskDrive");
-                                foreach (ManagementObject drive in searcher.Get())
+                                using var connection = new WmiConnection();
+                                var diskDrives = connection.CreateQuery("SELECT * FROM Win32_DiskDrive");
+                                foreach (var drive in diskDrives)
                                 {
                                     string deviceId = drive["DeviceID"]?.ToString();
                                     string model = drive["Model"]?.ToString();
@@ -110,9 +113,11 @@ namespace UStealth.DriveHelper
 
                                     try
                                     {
-                                        foreach (ManagementObject partition in drive.GetRelated("Win32_DiskPartition"))
+                                        var partitionQuery = connection.CreateQuery($"ASSOCIATORS OF {{Win32_DiskDrive.DeviceID='{EscapeWmiString(deviceId)}'}} WHERE AssocClass = Win32_DiskDriveToDiskPartition");
+                                        foreach (var partition in partitionQuery)
                                         {
-                                            foreach (ManagementObject logicalDisk in partition.GetRelated("Win32_LogicalDisk"))
+                                            var logicalQuery = connection.CreateQuery($"ASSOCIATORS OF {{Win32_DiskPartition.DeviceID='{EscapeWmiString(partition["DeviceID"]?.ToString())}'}} WHERE AssocClass = Win32_LogicalDiskToPartition");
+                                            foreach (var logicalDisk in logicalQuery)
                                             {
                                                 if (!string.IsNullOrEmpty(driveLetters))
                                                     driveLetters += ", ";
@@ -237,8 +242,9 @@ namespace UStealth.DriveHelper
             var drives = new List<string>();
             try
             {
-                var searcher = new System.Management.ManagementObjectSearcher("SELECT * FROM Win32_DiskDrive");
-                foreach (System.Management.ManagementObject drive in searcher.Get())
+                using var connection = new WmiConnection();
+                var diskDrives = connection.CreateQuery("SELECT DeviceID, Model, Size FROM Win32_DiskDrive");
+                foreach (var drive in diskDrives)
                 {
                     string deviceId = drive["DeviceID"]?.ToString();
                     string model = drive["Model"]?.ToString();
@@ -255,8 +261,9 @@ namespace UStealth.DriveHelper
         private static DriveInfoDisplay? FindSystemDrive()
         {
             string sysDrive = Environment.GetFolderPath(Environment.SpecialFolder.System).Substring(0, 2);
-            var searcher = new ManagementObjectSearcher("SELECT * FROM Win32_DiskDrive");
-            foreach (ManagementObject drive in searcher.Get())
+            using var connection = new WmiConnection();
+            var diskDrives = connection.CreateQuery("SELECT * FROM Win32_DiskDrive");
+            foreach (var drive in diskDrives)
             {
                 string deviceId = drive["DeviceID"]?.ToString();
                 string model = drive["Model"]?.ToString();
@@ -271,9 +278,11 @@ namespace UStealth.DriveHelper
 
                 try
                 {
-                    foreach (ManagementObject partition in drive.GetRelated("Win32_DiskPartition"))
+                    var partitionQuery = connection.CreateQuery($"ASSOCIATORS OF {{Win32_DiskDrive.DeviceID='{EscapeWmiString(deviceId)}'}} WHERE AssocClass = Win32_DiskDriveToDiskPartition");
+                    foreach (var partition in partitionQuery)
                     {
-                        foreach (ManagementObject logicalDisk in partition.GetRelated("Win32_LogicalDisk"))
+                        var logicalQuery = connection.CreateQuery($"ASSOCIATORS OF {{Win32_DiskPartition.DeviceID='{EscapeWmiString(partition["DeviceID"]?.ToString())}'}} WHERE AssocClass = Win32_LogicalDiskToPartition");
+                        foreach (var logicalDisk in logicalQuery)
                         {
                             if (!string.IsNullOrEmpty(driveLetters))
                                 driveLetters += ", ";
@@ -313,6 +322,11 @@ namespace UStealth.DriveHelper
                 }
             }
             return null;
+        }
+
+        private static string EscapeWmiString(string input)
+        {
+            return input?.Replace("\\", "\\\\") ?? string.Empty;
         }
 
         private static string FormatSize(string sizeStr)
@@ -382,8 +396,9 @@ namespace UStealth.DriveHelper
             try
             {
                 string sysDrive = Environment.GetFolderPath(Environment.SpecialFolder.System).Substring(0, 2);
-                var searcher = new ManagementObjectSearcher("SELECT * FROM Win32_DiskDrive");
-                foreach (ManagementObject drive in searcher.Get())
+                using var connection = new WmiConnection();
+                var diskDrives = connection.CreateQuery("SELECT * FROM Win32_DiskDrive");
+                foreach (var drive in diskDrives)
                 {
                     string deviceId = drive["DeviceID"]?.ToString();
                     string model = drive["Model"]?.ToString();
@@ -399,9 +414,11 @@ namespace UStealth.DriveHelper
                     // Find drive letters and volume info
                     try
                     {
-                        foreach (ManagementObject partition in drive.GetRelated("Win32_DiskPartition"))
+                        var partitionQuery = connection.CreateQuery($"ASSOCIATORS OF {{Win32_DiskDrive.DeviceID='{EscapeWmiString(deviceId)}'}} WHERE AssocClass = Win32_DiskDriveToDiskPartition");
+                        foreach (var partition in partitionQuery)
                         {
-                            foreach (ManagementObject logicalDisk in partition.GetRelated("Win32_LogicalDisk"))
+                            var logicalQuery = connection.CreateQuery($"ASSOCIATORS OF {{Win32_DiskPartition.DeviceID='{EscapeWmiString(partition["DeviceID"]?.ToString())}'}} WHERE AssocClass = Win32_LogicalDiskToPartition");
+                            foreach (var logicalDisk in logicalQuery)
                             {
                                 if (!string.IsNullOrEmpty(driveLetters))
                                     driveLetters += ", ";

--- a/UStealth.DriveHelper/Program.cs
+++ b/UStealth.DriveHelper/Program.cs
@@ -113,10 +113,10 @@ namespace UStealth.DriveHelper
 
                                     try
                                     {
-                                        var partitionQuery = connection.CreateQuery($"ASSOCIATORS OF {{Win32_DiskDrive.DeviceID='{EscapeWmiString(deviceId)}'}} WHERE AssocClass = Win32_DiskDriveToDiskPartition");
+                                        var partitionQuery = connection.CreateQuery($"ASSOCIATORS OF {{Win32_DiskDrive.DeviceID='{deviceId}'}} WHERE AssocClass=Win32_DiskDriveToDiskPartition");
                                         foreach (var partition in partitionQuery)
                                         {
-                                            var logicalQuery = connection.CreateQuery($"ASSOCIATORS OF {{Win32_DiskPartition.DeviceID='{EscapeWmiString(partition["DeviceID"]?.ToString())}'}} WHERE AssocClass = Win32_LogicalDiskToPartition");
+                                            var logicalQuery = connection.CreateQuery($"ASSOCIATORS OF {{Win32_DiskPartition.DeviceID='{partition["deviceId"]}'}} WHERE AssocClass=Win32_LogicalDiskToPartition");
                                             foreach (var logicalDisk in logicalQuery)
                                             {
                                                 if (!string.IsNullOrEmpty(driveLetters))
@@ -278,10 +278,10 @@ namespace UStealth.DriveHelper
 
                 try
                 {
-                    var partitionQuery = connection.CreateQuery($"ASSOCIATORS OF {{Win32_DiskDrive.DeviceID='{EscapeWmiString(deviceId)}'}} WHERE AssocClass = Win32_DiskDriveToDiskPartition");
+                    var partitionQuery = connection.CreateQuery($"ASSOCIATORS OF {{Win32_DiskDrive.DeviceID='{deviceId}'}} WHERE AssocClass=Win32_DiskDriveToDiskPartition");
                     foreach (var partition in partitionQuery)
                     {
-                        var logicalQuery = connection.CreateQuery($"ASSOCIATORS OF {{Win32_DiskPartition.DeviceID='{EscapeWmiString(partition["DeviceID"]?.ToString())}'}} WHERE AssocClass = Win32_LogicalDiskToPartition");
+                        var logicalQuery = connection.CreateQuery($"ASSOCIATORS OF {{Win32_DiskPartition.DeviceID='{partition["deviceId"]}'}} WHERE AssocClass=Win32_LogicalDiskToPartition");
                         foreach (var logicalDisk in logicalQuery)
                         {
                             if (!string.IsNullOrEmpty(driveLetters))
@@ -414,10 +414,10 @@ namespace UStealth.DriveHelper
                     // Find drive letters and volume info
                     try
                     {
-                        var partitionQuery = connection.CreateQuery($"ASSOCIATORS OF {{Win32_DiskDrive.DeviceID='{EscapeWmiString(deviceId)}'}} WHERE AssocClass = Win32_DiskDriveToDiskPartition");
+                        var partitionQuery = connection.CreateQuery($"ASSOCIATORS OF {{Win32_DiskDrive.DeviceID='{deviceId}'}} WHERE AssocClass=Win32_DiskDriveToDiskPartition");
                         foreach (var partition in partitionQuery)
                         {
-                            var logicalQuery = connection.CreateQuery($"ASSOCIATORS OF {{Win32_DiskPartition.DeviceID='{EscapeWmiString(partition["DeviceID"]?.ToString())}'}} WHERE AssocClass = Win32_LogicalDiskToPartition");
+                            var logicalQuery = connection.CreateQuery($"ASSOCIATORS OF {{Win32_DiskPartition.DeviceID='{partition["deviceId"]}'}} WHERE AssocClass=Win32_LogicalDiskToPartition");
                             foreach (var logicalDisk in logicalQuery)
                             {
                                 if (!string.IsNullOrEmpty(driveLetters))

--- a/UStealth.DriveHelper/UStealth.DriveHelper.csproj
+++ b/UStealth.DriveHelper/UStealth.DriveHelper.csproj
@@ -10,11 +10,11 @@
     <Nullable>enable</Nullable>
     <SelfContained>true</SelfContained>
     <IsAotCompatible>true</IsAotCompatible>
-    <PublishAot>False</PublishAot>
-    <PublishTrimmed>False</PublishTrimmed>
+    <PublishAot>True</PublishAot>
+    <PublishWmiLightStaticallyLinked>true</PublishWmiLightStaticallyLinked>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Spectre.Console" Version="0.50.0" />
-    <PackageReference Include="System.Management" Version="9.0.8" />
+    <PackageReference Include="WmiLight" Version="6.14.0" />
   </ItemGroup>
 </Project>

--- a/UStealth.ModularPipelines/Modules/PackAndPublishDriveHelperModule.cs
+++ b/UStealth.ModularPipelines/Modules/PackAndPublishDriveHelperModule.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ModularPipelines.Context;
+using ModularPipelines.DotNet.Extensions;
+using ModularPipelines.DotNet.Options;
+using ModularPipelines.Modules;
+using UStealth.ModularPipelines.Services;
+
+namespace UStealth.ModularPipelines.Modules
+{
+    public class PackAndPublishDriveHelperModule(FileService fileService) : Module<Command>
+    {
+        protected override async Task<Command?> ExecuteAsync(IPipelineContext context, CancellationToken cancellationToken)
+        {
+            var driveHelperProject = $@"{fileService.GetSolutionDirectory()}\UStealth.DriveHelper";
+            // Get all the publish profiles from the Properties folder
+            var publishProfiles = context.FileSystem.GetFiles($@"{driveHelperProject}\Properties"!, file => file.Exists );
+            var publishProfileNames = publishProfiles
+                .Where(f => f.Path.EndsWith(".pubxml", StringComparison.OrdinalIgnoreCase))
+                .Select(f => System.IO.Path.GetFileNameWithoutExtension(f.Path))
+                .ToList();
+            // Clean up the bin folder if it exists
+            if (context.FileSystem.FolderExists($@"{driveHelperProject}\bin"!))
+            {
+                context.FileSystem.DeleteFolder($@"{driveHelperProject}\bin"!);
+            }
+
+            // Get TFM dynamically
+            var msbuildOptions = new DotNetMsbuildOptions($@"{driveHelperProject}\UStealth.DriveHelper.csproj")
+            {
+                Arguments = ["-getProperty:TargetFramework"]
+            };
+            var tfmResult = await context.DotNet().Msbuild(msbuildOptions, cancellationToken);
+            var tfmOutput = tfmResult?.StandardOutput?.Trim();
+            var tfm = string.IsNullOrWhiteSpace(tfmOutput) ? "net9.0-windows" : tfmOutput;
+
+            foreach (var publishProfileName in publishProfileNames)
+            {
+                await context.DotNet().Publish(new DotNetPublishOptions()
+                {
+                    WorkingDirectory = driveHelperProject,
+                    Arguments = [$"/p:PublishProfile=\\Properties\\{publishProfileName}"]
+                }, cancellationToken);
+                var publishedDir = $@"{driveHelperProject}\bin\release\{tfm}\{publishProfileName}\publish";
+                var publishedExecutable = $@"{publishedDir}\UStealth.DriveHelper.exe";
+                var distributionFolder = Path.Combine(publishedDir, $"ustealth-cli-{publishProfileName}");
+                if (!Directory.Exists(distributionFolder))
+                {
+                    Directory.CreateDirectory(distributionFolder);
+                }
+                var renamedExecutable = context.FileSystem.CopyFile(publishedExecutable, $@"{distributionFolder}\ustealth.exe");
+                var zippedFolder = context.Zip.ZipFolder(distributionFolder,publishedDir);
+                context.FileSystem.MoveFile(zippedFolder, $@"{publishedDir}\ustealth-cli-{publishProfileName}.zip");
+                context.Logger.LogToConsole($"Published and zipped {publishProfileName} to {zippedFolder.Path}");
+            }
+            return await Task.FromResult<Command?>(new Command(null));
+        }
+    }
+}

--- a/UStealth.ModularPipelines/Program.cs
+++ b/UStealth.ModularPipelines/Program.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using ModularPipelines.Host;
+using UStealth.ModularPipelines.Modules;
+using UStealth.ModularPipelines.Services;
+
+await PipelineHostBuilder.Create()
+    .ConfigureServices((context, collection) =>
+    {
+        collection.AddSingleton<FileService>();
+    })
+    .AddModule<PackAndPublishDriveHelperModule>()
+    .ExecutePipelineAsync();

--- a/UStealth.ModularPipelines/Services/FileService.cs
+++ b/UStealth.ModularPipelines/Services/FileService.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.IO;
+
+namespace UStealth.ModularPipelines.Services
+{
+    public class FileService
+    {
+        public string GetSolutionDirectory()
+        {
+            var currentDir = new DirectoryInfo(AppContext.BaseDirectory);
+
+            while (currentDir != null && !currentDir.GetFiles("*.sln").Any())
+            {
+                currentDir = currentDir.Parent;
+            }
+
+            return currentDir == null ? throw new InvalidOperationException("Solution directory not found.") : currentDir.FullName;
+        }
+    }
+}

--- a/UStealth.ModularPipelines/UStealth.ModularPipelines.csproj
+++ b/UStealth.ModularPipelines/UStealth.ModularPipelines.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ModularPipelines.DotNet" Version="2.47.8" />
+  </ItemGroup>
+
+</Project>

--- a/UStealth.sln
+++ b/UStealth.sln
@@ -21,6 +21,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UStealth.Tests", "UStealth.Tests\UStealth.Tests.csproj", "{020689EF-C91F-2DC2-CB85-824697C7E217}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UStealth.ModularPipelines", "UStealth.ModularPipelines\UStealth.ModularPipelines.csproj", "{EFC76260-3694-4486-9B4D-F2B567DB525D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -93,6 +95,18 @@ Global
 		{020689EF-C91F-2DC2-CB85-824697C7E217}.Release|x64.Build.0 = Release|x64
 		{020689EF-C91F-2DC2-CB85-824697C7E217}.Release|x86.ActiveCfg = Release|x86
 		{020689EF-C91F-2DC2-CB85-824697C7E217}.Release|x86.Build.0 = Release|x86
+		{EFC76260-3694-4486-9B4D-F2B567DB525D}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{EFC76260-3694-4486-9B4D-F2B567DB525D}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{EFC76260-3694-4486-9B4D-F2B567DB525D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EFC76260-3694-4486-9B4D-F2B567DB525D}.Debug|x64.Build.0 = Debug|Any CPU
+		{EFC76260-3694-4486-9B4D-F2B567DB525D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EFC76260-3694-4486-9B4D-F2B567DB525D}.Debug|x86.Build.0 = Debug|Any CPU
+		{EFC76260-3694-4486-9B4D-F2B567DB525D}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{EFC76260-3694-4486-9B4D-F2B567DB525D}.Release|ARM64.Build.0 = Release|Any CPU
+		{EFC76260-3694-4486-9B4D-F2B567DB525D}.Release|x64.ActiveCfg = Release|Any CPU
+		{EFC76260-3694-4486-9B4D-F2B567DB525D}.Release|x64.Build.0 = Release|Any CPU
+		{EFC76260-3694-4486-9B4D-F2B567DB525D}.Release|x86.ActiveCfg = Release|Any CPU
+		{EFC76260-3694-4486-9B4D-F2B567DB525D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This pull request introduces a new modular pipeline project for building and packaging the DriveHelper utility, and refactors the DriveHelper codebase to use the `WmiLight` library for WMI queries, enabling native AOT (Ahead-Of-Time) compilation. The changes improve build automation, simplify WMI usage, and enhance compatibility with native publishing.

**Build system and packaging improvements:**

* Added a new project, `UStealth.ModularPipelines`, which defines a pipeline module (`PackAndPublishDriveHelperModule`) to automate building, publishing, renaming, zipping, and organizing DriveHelper executables for each publish profile. This includes supporting services and configuration for modular pipelines. [[1]](diffhunk://#diff-bdb7cee1e41f90b5e4d6b0e8ee4b3bacf852632c1cfbe9e3d5303063e59f1317R1-R62) [[2]](diffhunk://#diff-de0b00b9762ebddb9c8981dc323d496ddab5bdfd7ab9f293a10e76fc4f1dec41R1-R12) [[3]](diffhunk://#diff-568f202863d116b04d659efee078b600ef75c7fb86e59f9ff777295a4e70a125R1-R20) [[4]](diffhunk://#diff-039ddc13b620e35773e9cffc53fd526b77da39dded97ef02fdf4a2535c4c18dcR1-R16) [[5]](diffhunk://#diff-df1cd52ecfc802f9e7ac01d67a37f28a60d93f006793329c187fbcc744542315R24-R25) [[6]](diffhunk://#diff-df1cd52ecfc802f9e7ac01d67a37f28a60d93f006793329c187fbcc744542315R98-R109)
* Updated the solution file (`UStealth.sln`) to include the new modular pipelines project and its build configurations. [[1]](diffhunk://#diff-df1cd52ecfc802f9e7ac01d67a37f28a60d93f006793329c187fbcc744542315R24-R25) [[2]](diffhunk://#diff-df1cd52ecfc802f9e7ac01d67a37f28a60d93f006793329c187fbcc744542315R98-R109)

**DriveHelper codebase refactoring for WMI and AOT:**

* Replaced usage of `System.Management` with `WmiLight` for all WMI queries in `Program.cs`, refactoring device, partition, and logical disk queries accordingly. This improves compatibility with native AOT publishing. [[1]](diffhunk://#diff-6576dbe7e1766e7309c48b4567ef33675e4c0276cea860e20ffa1abbfc1f781aL6-R6) [[2]](diffhunk://#diff-6576dbe7e1766e7309c48b4567ef33675e4c0276cea860e20ffa1abbfc1f781aL97-R101) [[3]](diffhunk://#diff-6576dbe7e1766e7309c48b4567ef33675e4c0276cea860e20ffa1abbfc1f781aL113-R120) [[4]](diffhunk://#diff-6576dbe7e1766e7309c48b4567ef33675e4c0276cea860e20ffa1abbfc1f781aL240-R247) [[5]](diffhunk://#diff-6576dbe7e1766e7309c48b4567ef33675e4c0276cea860e20ffa1abbfc1f781aL258-R266) [[6]](diffhunk://#diff-6576dbe7e1766e7309c48b4567ef33675e4c0276cea860e20ffa1abbfc1f781aL274-R285) [[7]](diffhunk://#diff-6576dbe7e1766e7309c48b4567ef33675e4c0276cea860e20ffa1abbfc1f781aL385-R401) [[8]](diffhunk://#diff-6576dbe7e1766e7309c48b4567ef33675e4c0276cea860e20ffa1abbfc1f781aL402-R421)
* Added a helper method `EscapeWmiString` to safely escape WMI strings for queries.

**Project configuration updates:**

* Updated `UStealth.DriveHelper.csproj` to remove `System.Management`, add `WmiLight`, enable AOT publishing, and statically link `WmiLight`.

**Other code improvements:**

* Wrapped the elevation check in a `#if !DEBUG` block to allow easier debugging without requiring admin privileges. [[1]](diffhunk://#diff-6576dbe7e1766e7309c48b4567ef33675e4c0276cea860e20ffa1abbfc1f781aR24) [[2]](diffhunk://#diff-6576dbe7e1766e7309c48b4567ef33675e4c0276cea860e20ffa1abbfc1f781aR44)