### PR TITLE
Renamed some of the commands in U-Stealth CLI

### DIFF
--- a/UStealth.DriveHelper/Program.cs
+++ b/UStealth.DriveHelper/Program.cs
@@ -49,7 +49,7 @@ namespace UStealth.DriveHelper
                     var command = AnsiConsole.Prompt(
                         new SelectionPrompt<string>()
                             .Title("[green]Select a command[/]")
-                            .AddChoices(new[] { "toggleboot", "readboot", "listdrives", "exit" })
+                            .AddChoices("list drives","hide / unhide","read boot", "exit")
                     );
 
                     if (command == "exit")
@@ -58,7 +58,7 @@ namespace UStealth.DriveHelper
                     string device = null;
                     string hexData = null;
 
-                    if (command is "toggleboot" or "readboot")
+                    if (command is "hide / unhide" or "read boot")
                     {
                         // List drives and let user select
                         var drives = GetDrivesForPrompt();
@@ -75,22 +75,18 @@ namespace UStealth.DriveHelper
                         // Extract deviceId from label
                         device = device.Split(' ')[0];
                     }
-                    if (command == "writeboot")
-                    {
-                        hexData = AnsiConsole.Ask<string>("[green]Enter hex data to write to boot sector[/]");
-                    }
 
                     // Call the appropriate method
                     int result = 0;
                     switch (command)
                     {
-                        case "toggleboot":
+                        case "hide / unhide":
                             result = ToggleBoot(device);
                             break;
-                        case "readboot":
+                        case "read boot":
                             result = ReadBoot(device);
                             break;
-                        case "listdrives":
+                        case "list drives":
                             // Interactive Spectre.Console table view
                             var drives = new List<DriveInfoDisplay>();
                             try

--- a/UStealth.DriveHelper/UStealth.DriveHelper.csproj
+++ b/UStealth.DriveHelper/UStealth.DriveHelper.csproj
@@ -6,7 +6,7 @@
     <Platforms>x86;x64;ARM64;AnyCPU</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
-    <Version>1.0.2.0</Version>
+    <Version>1.0.3.0</Version>
     <Nullable>enable</Nullable>
     <SelfContained>true</SelfContained>
     <IsAotCompatible>true</IsAotCompatible>


### PR DESCRIPTION
This pull request updates the user interface and command logic in `UStealth.DriveHelper` to improve clarity and usability. The most significant changes involve renaming commands for better user understanding and removing the unused "writeboot" command, along with a version bump for the application.

**User interface and command improvements:**

* The command prompt choices in `Program.cs` have been updated to more descriptive names: "list drives", "hide / unhide", "read boot", and "exit", replacing the previous less clear options.
* The logic for handling commands has been updated to use the new names ("hide / unhide" and "read boot") throughout the code, ensuring consistency and preventing errors. [[1]](diffhunk://#diff-6576dbe7e1766e7309c48b4567ef33675e4c0276cea860e20ffa1abbfc1f781aL61-R61) [[2]](diffhunk://#diff-6576dbe7e1766e7309c48b4567ef33675e4c0276cea860e20ffa1abbfc1f781aL78-R83)
* The "writeboot" command and its associated input prompt have been removed, simplifying the available functionality and user experience.

**Versioning:**

* The application version in `UStealth.DriveHelper.csproj` has been incremented from 1.0.2.0 to 1.0.3.0 to reflect these changes.