### PR TITLE
GitHub actions: CLI Artifact creation is now automated

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -1,6 +1,7 @@
 # This workflow will build a .NET project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
+
 name: CLI Build and Packaging
 
 on:
@@ -12,17 +13,60 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 9.0.x
-    - name: Restore dependencies
-      run: dotnet restore UStealth.CICD.slnx
-    - name: Build
-      run: dotnet build UStealth.CICD.slnx --no-restore
-    - name: Test
-      run: dotnet test .\UStealth.Tests\UStealth.Tests.csproj --no-build --verbosity normal --framework net9.0-windows
-    - name: Build Artifacts
-      run: dotnet run .\UStealth.ModularPipelines\UStealth.ModularPipelines.csproj
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+      - name: Restore dependencies
+        run: dotnet restore UStealth.CICD.slnx
+      - name: Build
+        run: dotnet build UStealth.CICD.slnx --no-restore
+      - name: Upload build outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: |
+            **/bin/**
+            **/obj/**
+
+  test:
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+      - name: Test
+        run: |
+          if [ "${{ runner.os }}" == "Windows" ]; then \
+            dotnet test .\UStealth.Tests\UStealth.Tests.csproj --no-build --verbosity normal --framework net9.0-windows; \
+          else \
+            dotnet test ./UStealth.Tests/UStealth.Tests.csproj --no-build --verbosity normal --framework net9.0; \
+          fi
+
+  artifacts:
+    needs: test
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+      - name: Build Artifacts
+        run: dotnet run .\UStealth.ModularPipelines\UStealth.ModularPipelines.csproj
       

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Prepare ZIPs for upload
         run: |
           mkdir -p temp-zips
-          for %f in (UStealth.DriveHelper\bin\Release\**\*.zip) do copy "%f" temp-zips\
+          for %f in (UStealth.DriveHelper\bin\Release\**\*.zip) do copy "%f" temp-zips\\
         shell: cmd
       - name: Upload DriveHelper ZIPs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           name: build-output
       - name: Build Artifacts
-        run: dotnet run .\\UStealth.ModularPipelines\\UStealth.ModularPipelines.csproj
+        run: dotnet run --project .\\UStealth.ModularPipelines\\UStealth.ModularPipelines.csproj
       - name: Upload DriveHelper ZIPs
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -48,7 +48,7 @@ jobs:
           name: build-output
       - name: Test
         run: |
-          if [ "${{ runner.os }}" == "Windows" ]; then
+          if [ "${{ runner.os }}" = "Windows" ]; then
             dotnet test .\UStealth.Tests\UStealth.Tests.csproj --no-build --verbosity normal --framework net9.0-windows
           else
             dotnet test ./UStealth.Tests/UStealth.Tests.csproj --no-build --verbosity normal --framework net9.0

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -72,8 +72,8 @@ jobs:
         run: dotnet run --project .\\UStealth.ModularPipelines\\UStealth.ModularPipelines.csproj
       - name: Prepare ZIPs for upload
         run: |
-          mkdir -p temp-zips
-          for %f in (UStealth.DriveHelper\bin\Release\**\*.zip) do copy "%f" temp-zips\\
+          mkdir temp-zips
+          for /R UStealth.DriveHelper\bin\Release %f in (*.zip) do copy "%f" temp-zips\
         shell: cmd
       - name: Upload DriveHelper ZIPs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -70,4 +70,8 @@ jobs:
           name: build-output
       - name: Build Artifacts
         run: dotnet run .\\UStealth.ModularPipelines\\UStealth.ModularPipelines.csproj
-      
+      - name: Upload DriveHelper ZIPs
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-zips
+          path: UStealth.DriveHelper\\bin\\Release\\**\\*.zip

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -50,9 +50,9 @@ jobs:
         shell: bash
         run: |
           if [ "${{ runner.os }}" = "Windows" ]; then
-            dotnet test .\UStealth.Tests\UStealth.Tests.csproj --no-build --verbosity normal --framework net9.0-windows
+            dotnet test .\\UStealth.Tests\\UStealth.Tests.csproj --no-build --verbosity normal --framework net9.0-windows
           else
-            dotnet test ./UStealth.Tests/UStealth.Tests.csproj --no-build --verbosity normal --framework net9.0
+            dotnet test .//UStealth.Tests//UStealth.Tests.csproj --no-build --verbosity normal --framework net9.0
           fi
 
   artifacts:

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -48,10 +48,10 @@ jobs:
           name: build-output
       - name: Test
         run: |
-          if [ "${{ runner.os }}" == "Windows" ]; then \
-            dotnet test .\UStealth.Tests\UStealth.Tests.csproj --no-build --verbosity normal --framework net9.0-windows; \
-          else \
-            dotnet test ./UStealth.Tests/UStealth.Tests.csproj --no-build --verbosity normal --framework net9.0; \
+          if [ "${{ runner.os }}" == "Windows" ]; then
+            dotnet test .\UStealth.Tests\UStealth.Tests.csproj --no-build --verbosity normal --framework net9.0-windows
+          else
+            dotnet test ./UStealth.Tests/UStealth.Tests.csproj --no-build --verbosity normal --framework net9.0
           fi
 
   artifacts:

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -70,8 +70,13 @@ jobs:
           name: build-output
       - name: Build Artifacts
         run: dotnet run --project .\\UStealth.ModularPipelines\\UStealth.ModularPipelines.csproj
+      - name: Prepare ZIPs for upload
+        run: |
+          mkdir -p temp-zips
+          for %f in (UStealth.DriveHelper\bin\Release\**\*.zip) do copy "%f" temp-zips\
+        shell: cmd
       - name: Upload DriveHelper ZIPs
         uses: actions/upload-artifact@v4
         with:
           name: cli-zips
-          path: UStealth.DriveHelper\\bin\\Release\\**\\*.zip
+          path: temp-zips\*.zip

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -1,7 +1,7 @@
 # This workflow will build a .NET project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
-name: .NET
+name: CLI Build and Packaging
 
 on:
   workflow_dispatch:

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           name: build-output
       - name: Test
+        shell: bash
         run: |
           if [ "${{ runner.os }}" = "Windows" ]; then
             dotnet test .\UStealth.Tests\UStealth.Tests.csproj --no-build --verbosity normal --framework net9.0-windows

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -79,4 +79,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: cli-zips
-          path: temp-zips\*.zip
+          path: temp-zips\\*.zip

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -52,7 +52,7 @@ jobs:
           if [ "${{ runner.os }}" = "Windows" ]; then
             dotnet test .\\UStealth.Tests\\UStealth.Tests.csproj --verbosity normal --framework net9.0-windows
           else
-            dotnet test .//UStealth.Tests//UStealth.Tests.csproj--verbosity normal --framework net9.0
+            dotnet test .//UStealth.Tests//UStealth.Tests.csproj --verbosity normal --framework net9.0
           fi
 
   artifacts:

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Build
       run: dotnet build UStealth.CICD.slnx --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal --framework net9.0-windows
+      run: dotnet test .\UStealth.Tests\UStealth.Tests.csproj --no-build --verbosity normal --framework net9.0-windows
     - name: Build Artifacts
       run: dotnet run .\UStealth.ModularPipelines\UStealth.ModularPipelines.csproj
       

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -50,9 +50,9 @@ jobs:
         shell: bash
         run: |
           if [ "${{ runner.os }}" = "Windows" ]; then
-            dotnet test .\\UStealth.Tests\\UStealth.Tests.csproj --no-build --verbosity normal --framework net9.0-windows
+            dotnet test .\\UStealth.Tests\\UStealth.Tests.csproj --verbosity normal --framework net9.0-windows
           else
-            dotnet test .//UStealth.Tests//UStealth.Tests.csproj --no-build --verbosity normal --framework net9.0
+            dotnet test .//UStealth.Tests//UStealth.Tests.csproj--verbosity normal --framework net9.0
           fi
 
   artifacts:
@@ -69,5 +69,5 @@ jobs:
         with:
           name: build-output
       - name: Build Artifacts
-        run: dotnet run .\UStealth.ModularPipelines\UStealth.ModularPipelines.csproj
+        run: dotnet run .\\UStealth.ModularPipelines\\UStealth.ModularPipelines.csproj
       

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -72,9 +72,9 @@ jobs:
         run: dotnet run --project .\\UStealth.ModularPipelines\\UStealth.ModularPipelines.csproj
       - name: Prepare ZIPs for upload
         run: |
-          mkdir temp-zips
-          for /R UStealth.DriveHelper\bin\Release %f in (*.zip) do copy "%f" temp-zips\
-        shell: cmd
+          New-Item ".\temp-zips" -ItemType Directory -Force
+          Get-ChildItem ".\UStealth.DriveHelper\bin\Release" -Filter *.zip -Recurse | Copy-Item -Destination ".\temp-zips"
+        shell: pwsh
       - name: Upload DriveHelper ZIPs
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
-          if [ "${{ runner.os }}" = "Windows" ]; then
+          if [ "${{ runner.os }}" == "Windows" ]; then
             dotnet test .\\UStealth.Tests\\UStealth.Tests.csproj --verbosity normal --framework net9.0-windows
           else
             dotnet test .//UStealth.Tests//UStealth.Tests.csproj --verbosity normal --framework net9.0

--- a/UStealth.DriveHelper/Program.cs
+++ b/UStealth.DriveHelper/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Mime;
@@ -92,12 +93,7 @@ namespace UStealth.DriveHelper
                             continue; // Skip the "Command finished" message
                         case "list drives":
                             // Interactive Spectre.Console table view
-                            var drives = new List<DriveInfoDisplay>();
-#if WINDOWS
-                            drives = Windows.GetDrives();
-#else
-                            drives = Linux.GetDrives();
-#endif
+                            var drives = GetDrives();
                             try
                             {
                                 // Print as Spectre.Console table
@@ -176,6 +172,20 @@ namespace UStealth.DriveHelper
                 Console.Error.WriteLine($"Error: {ex.Message}");
                 return 110;
             }
+        }
+
+        /// <summary>
+        /// Helper to get drives as a collection of DriveInfoDisplay
+        /// </summary>
+        /// <returns></returns>
+        internal static IEnumerable<DriveInfoDisplay> GetDrives()
+        {
+            var drives = new List<DriveInfoDisplay>();
+#if WINDOWS
+            return Windows.GetDrives();
+#else
+            return Linux.GetDrives();
+#endif
         }
 
         /// <summary>

--- a/UStealth.Tests/DriveHelperTests.cs
+++ b/UStealth.Tests/DriveHelperTests.cs
@@ -54,10 +54,10 @@ namespace UStealth.Tests
         {
             var method = typeof(Program).GetMethod("ListDrives", BindingFlags.Static | BindingFlags.NonPublic);
             var originalOut = Console.Out;
-            using var sw = new System.IO.StringWriter();
-            Console.SetOut(sw);
             try
             {
+                using var sw = new System.IO.StringWriter();
+                Console.SetOut(sw);
                 method.Invoke(null, null);
                 Console.Out.Flush();
                 var output = sw.ToString();

--- a/UStealth.Tests/DriveHelperTests.cs
+++ b/UStealth.Tests/DriveHelperTests.cs
@@ -65,8 +65,14 @@ namespace UStealth.Tests
                 var lines = output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
                 string json = lines.Length > 0 ? lines[^1] : string.Empty;
                 if (string.IsNullOrWhiteSpace(json)) return [];
-                var drives = JsonSerializer.Deserialize(json, typeof(List<Program.DriveInfoDisplay>), new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) as List<Program.DriveInfoDisplay>;
+                var drives = JsonSerializer.Deserialize<List<Program.DriveInfoDisplay>>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
                 return drives ?? [];
+            }
+            catch(Exception exception)
+            {
+                Console.SetOut(originalOut);
+                Console.WriteLine(exception.Message);
+                throw;
             }
             finally
             {

--- a/UStealth.Tests/DriveHelperTests.cs
+++ b/UStealth.Tests/DriveHelperTests.cs
@@ -24,7 +24,7 @@ namespace UStealth.Tests
         [Test]
         public async Task ListDrives_IntegrationTest()
         {
-            var drives = InvokeListDrives();
+            var drives = Program.GetDrives();
             await Assert.That(drives).IsNotNull();
             await Assert.That(drives.Count).IsGreaterThan(0);
             foreach (var d in drives)
@@ -36,7 +36,7 @@ namespace UStealth.Tests
         [Test]
         public async Task CannotToggleSystemDrive()
         {
-            var drives = InvokeListDrives();
+            var drives = Program.GetDrives().ToList();
             var systemDrive = drives.Find(d => d.IsSystemDrive);
             await Assert.That(systemDrive).IsNotNull();
             // Simulate the logic that would prevent toggling the system drive
@@ -50,35 +50,6 @@ namespace UStealth.Tests
             }
         }
 
-        private List<Program.DriveInfoDisplay> InvokeListDrives()
-        {
-            var method = typeof(Program).GetMethod("ListDrives", BindingFlags.Static | BindingFlags.NonPublic);
-            var originalOut = Console.Out;
-            try
-            {
-                using var sw = new System.IO.StringWriter();
-                Console.SetOut(sw);
-                method.Invoke(null, null);
-                Console.Out.Flush();
-                var output = sw.ToString();
-                // Find the JSON output (last line)
-                var lines = output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
-                string json = lines.Length > 0 ? lines[^1] : string.Empty;
-                if (string.IsNullOrWhiteSpace(json)) return [];
-                var drives = JsonSerializer.Deserialize<List<Program.DriveInfoDisplay>>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                return drives ?? [];
-            }
-            catch(Exception exception)
-            {
-                Console.SetOut(originalOut);
-                Console.WriteLine(exception.Message);
-                throw;
-            }
-            finally
-            {
-                Console.SetOut(originalOut);
-            }
-        }
 
         private int InvokeToggle(string device)
         {


### PR DESCRIPTION
This pull request improves the .NET CLI build and packaging workflow and simplifies the way drives are listed in both the application and its tests. The key changes include restructuring the GitHub Actions workflow to better separate build, test, and artifact steps, and refactoring the drive listing logic in `UStealth.DriveHelper` to make it more testable and maintainable.

**CI/CD Workflow Improvements:**

* The `.github/workflows/dotnet-build.yml` workflow is restructured to have distinct build, test, and artifact upload jobs. Build outputs are now uploaded and reused across jobs, and packaging steps are separated, improving clarity and efficiency. [[1]](diffhunk://#diff-ad500d44fcdc80118f5126903c29ba356c669ce8c155498faed0eb9272137d53L4-R5) [[2]](diffhunk://#diff-ad500d44fcdc80118f5126903c29ba356c669ce8c155498faed0eb9272137d53R25-R82)

**Codebase Refactoring and Test Improvements:**

* Introduced a new `GetDrives()` helper method in `Program.cs` to encapsulate platform-specific drive listing logic, replacing direct calls to `Windows.GetDrives()`/`Linux.GetDrives()` in the main method. [[1]](diffhunk://#diff-6576dbe7e1766e7309c48b4567ef33675e4c0276cea860e20ffa1abbfc1f781aL95-R96) [[2]](diffhunk://#diff-6576dbe7e1766e7309c48b4567ef33675e4c0276cea860e20ffa1abbfc1f781aR177-R190)
* Updated tests in `UStealth.Tests/DriveHelperTests.cs` to use the new `GetDrives()` method directly, removing the brittle `InvokeListDrives` reflection-based helper and simplifying test logic. [[1]](diffhunk://#diff-f95ea923fe0fd71306c893ca63569f795a9b192f1593cf64760892fe43007160L27-R27) [[2]](diffhunk://#diff-f95ea923fe0fd71306c893ca63569f795a9b192f1593cf64760892fe43007160L39-R39) [[3]](diffhunk://#diff-f95ea923fe0fd71306c893ca63569f795a9b192f1593cf64760892fe43007160L53-L75)

**Minor Code Cleanups:**

* Added missing `using System.Collections;` in `Program.cs` to support new method signatures.