### PR TITLE
Added Navigation Style Setting to WinUI app

### DIFF
--- a/UStealth.WinUI/MainWindow.xaml
+++ b/UStealth.WinUI/MainWindow.xaml
@@ -26,9 +26,11 @@
         </TitleBar>
 
         <NavigationView
+            x:Name="NavigationViewControl"
             Grid.Row="1"
+            x:FieldModifier="public"
             IsBackButtonVisible="Collapsed"
-            PaneDisplayMode="Top"
+            PaneDisplayMode="{x:Bind NavigationStyle}"
             SelectionChanged="NavigationView_OnSelectionChanged"
             SelectionFollowsFocus="Enabled">
             <NavigationView.MenuItems>

--- a/UStealth.WinUI/MainWindow.xaml.cs
+++ b/UStealth.WinUI/MainWindow.xaml.cs
@@ -9,13 +9,19 @@ namespace UStealth.WinUI
     public sealed partial class MainWindow : Window
     {
 
+        public new static MainWindow? Current { get; private set; }
         public string AppName => "U-Stealth";
         public string AppVersion => $"v{GetAppVersion()}";
-        public Microsoft.UI.Xaml.Media.Imaging.BitmapImage AppIconUri => new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(new Uri("ms-appx:///Assets/StoreLogo.png"));
+        public Microsoft.UI.Xaml.Media.Imaging.BitmapImage AppIconUri => new(new Uri("ms-appx:///Assets/StoreLogo.png"));
+
+        public  NavigationViewPaneDisplayMode NavigationStyle { get; set; }
+
 
         public MainWindow()
         {
+            Current = this;
             InitializeComponent();
+            GetNavigationStyle();
             ExtendsContentIntoTitleBar = true;
             AppIcon.ImageSource = AppIconUri;
             TitleBar.Title = $"{AppName} - {AppVersion}";
@@ -38,11 +44,6 @@ namespace UStealth.WinUI
         }
 
 
-        //C# code behind
-        private void NavView_ItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
-        {
-            // Don't handle settings here, as it is handled by SelectionChanged
-        }
 
         private void NavigationView_OnSelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
         {
@@ -62,6 +63,20 @@ namespace UStealth.WinUI
                 pageType = typeof(SettingsPage);
             }
             rootFrame.NavigateToType(pageType, null, navOptions);
+        }
+
+
+        private void GetNavigationStyle()
+        {
+            var navStyle = Windows.Storage.ApplicationData.Current.LocalSettings.Values["NavigationStyle"]?.ToString();
+            NavigationStyle = navStyle switch
+            {
+                "Left" => NavigationViewPaneDisplayMode.Left,
+                "Left Compat" => NavigationViewPaneDisplayMode.LeftCompact,
+                "Left Minimal" => NavigationViewPaneDisplayMode.LeftMinimal,
+                "Auto" => NavigationViewPaneDisplayMode.Auto,
+                _ => NavigationViewPaneDisplayMode.Top
+            };
         }
     }
 }

--- a/UStealth.WinUI/Pages/SettingsPage.xaml
+++ b/UStealth.WinUI/Pages/SettingsPage.xaml
@@ -72,6 +72,47 @@
                             </ComboBox>
                         </Grid>
                     </Border>
+                    <!--  Navigation style card  -->
+                    <Border
+                        Margin="10,0,10,0"
+                        Padding="16"
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        CornerRadius="8">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock
+                                Grid.Column="0"
+                                Margin="0,0,16,0"
+                                VerticalAlignment="Center"
+                                FontFamily="Segoe MDL2 Assets"
+                                FontSize="24"
+                                Text="&#xE8A7;" />
+                            <StackPanel Grid.Column="1">
+                                <TextBlock FontWeight="SemiBold" Text="Navigation style" />
+                                <TextBlock
+                                    FontSize="12"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Text="Choose how navigation is displayed" />
+                            </StackPanel>
+                            <ComboBox
+                                x:Name="NavigationStyleComboBox"
+                                Grid.Column="2"
+                                Width="100"
+                                HorizontalAlignment="Right"
+                                SelectedValuePath="Tag"
+                                SelectionChanged="NavigationStyleComboBox_OnSelectionChanged">
+                                <ComboBoxItem Content="Top" Tag="Top" />
+                                <ComboBoxItem Content="Left" Tag="Left" />
+                                <ComboBoxItem Content="Left Compact" Tag="Left Compact" />
+                                <ComboBoxItem Content="Left Minimal" Tag="Left Minimal" />
+                                <ComboBoxItem Content="Left Auto" Tag="Left Auto" />
+                            </ComboBox>
+                        </Grid>
+                    </Border>
                 </StackPanel>
             </StackPanel>
         </StackPanel>

--- a/UStealth.WinUI/Pages/SettingsPage.xaml.cs
+++ b/UStealth.WinUI/Pages/SettingsPage.xaml.cs
@@ -28,6 +28,15 @@ namespace UStealth.WinUI.Pages
         private void Page_Loaded()
         {
             App.Current.ThemeService.SetThemeComboBoxDefaultItem(ThemeComboBox);
+            NavigationStyleComboBox.SelectedValue = MainWindow.Current!.NavigationStyle switch
+            {
+                NavigationViewPaneDisplayMode.Top => "Top",
+                NavigationViewPaneDisplayMode.Left => "Left",
+                NavigationViewPaneDisplayMode.LeftCompact => "Left Compact",
+                NavigationViewPaneDisplayMode.LeftMinimal => "Left Minimal",
+                NavigationViewPaneDisplayMode.Auto => "Auto",
+                _ => "Top"
+            };
         }
 
 
@@ -39,8 +48,8 @@ namespace UStealth.WinUI.Pages
                 if (ThemeComboBox.SelectedItem is not ComboBoxItem selectedItem) return;
                 string selectedTheme = selectedItem.Tag?.ToString() ?? "Default";
                 if (selectedTheme == "Default")
-                {
-                    await ClearTheme();
+                { 
+                    ClearTheme();
                 }
                 else
                 {
@@ -53,14 +62,15 @@ namespace UStealth.WinUI.Pages
             }
         }
 
-        
 
-        private async Task ClearTheme()
-        { 
+
+        private void ClearTheme()
+        {
             Windows.Storage.ApplicationData.Current.LocalSettings.Values.Remove("AppTheme");
         }
 
-        private async Task ShowDialog(string title,string message)
+
+        private async Task ShowDialog(string title, string message)
         {
             var dialog = new ContentDialog
             {
@@ -70,6 +80,24 @@ namespace UStealth.WinUI.Pages
                 XamlRoot = this.XamlRoot // Use the page's XamlRoot
             };
             await dialog.ShowAsync();
+        }
+
+        private void NavigationStyleComboBox_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (NavigationStyleComboBox.SelectedItem is not ComboBoxItem selectedItem) return;
+            string selectedStyle = selectedItem.Tag?.ToString() ?? "Top";
+            Windows.Storage.ApplicationData.Current.LocalSettings.Values["NavigationStyle"] = selectedStyle;
+            MainWindow.Current!.NavigationStyle = selectedStyle switch
+            {
+                "Top" => NavigationViewPaneDisplayMode.Top,
+                "Left" => NavigationViewPaneDisplayMode.Left,
+                "Left Compact" => NavigationViewPaneDisplayMode.LeftCompact,
+                "Left Minimal" => NavigationViewPaneDisplayMode.LeftMinimal,
+                "Auto" => NavigationViewPaneDisplayMode.Auto,
+                _ => MainWindow.Current.NavigationStyle
+            };
+            
+            MainWindow.Current.NavigationViewControl.PaneDisplayMode = MainWindow.Current.NavigationStyle;
         }
     }
 }


### PR DESCRIPTION
This pull request adds support for customizing the navigation pane display mode in the application's main window through a new setting in the Settings page. Users can now choose how navigation is displayed (Top, Left, Left Compact, Left Minimal, or Auto), and their preference is saved and applied across sessions. Additionally, some minor code cleanups are included.

**Navigation style customization:**

* Added a new "Navigation style" setting in `SettingsPage.xaml` with a ComboBox allowing users to select the navigation pane display mode. (`UStealth.WinUI/Pages/SettingsPage.xaml`)
* Implemented logic to save the selected navigation style to local settings and update the main window's navigation pane accordingly. (`UStealth.WinUI/Pages/SettingsPage.xaml.cs`) [[1]](diffhunk://#diff-86bf6bfe0fdb45ee6cb102e80438b32c4553b9e85c87f82d64aaaa59916349cbR31-R39) [[2]](diffhunk://#diff-86bf6bfe0fdb45ee6cb102e80438b32c4553b9e85c87f82d64aaaa59916349cbR84-R101)
* Modified `MainWindow.xaml` and `MainWindow.xaml.cs` to bind the navigation pane display mode to the user's selected style and initialize it on startup. (`UStealth.WinUI/MainWindow.xaml`, `UStealth.WinUI/MainWindow.xaml.cs`) [[1]](diffhunk://#diff-4cbad2f35c92a316c4bc6d3c9bf6d2a9a265d1f3b21cdb353ae9e26dd9d0c06cR29-R33) [[2]](diffhunk://#diff-4f986e74e5e258530dd351c6506ffb690c1f9138a38fb807bdd3fc73c8cc33bdR12-R24) [[3]](diffhunk://#diff-4f986e74e5e258530dd351c6506ffb690c1f9138a38fb807bdd3fc73c8cc33bdR67-R80)

**Code cleanups and minor improvements:**

* Refactored theme clearing logic to be synchronous as it no longer needs to be asynchronous. (`UStealth.WinUI/Pages/SettingsPage.xaml.cs`) [[1]](diffhunk://#diff-86bf6bfe0fdb45ee6cb102e80438b32c4553b9e85c87f82d64aaaa59916349cbL43-R52) [[2]](diffhunk://#diff-86bf6bfe0fdb45ee6cb102e80438b32c4553b9e85c87f82d64aaaa59916349cbL58-R72)
* Removed unused navigation event handler for cleaner code. (`UStealth.WinUI/MainWindow.xaml.cs`)