### PR TITLE
WinUI  New Setting:  Window size

### DIFF
--- a/UStealth.WinUI/App.xaml.cs
+++ b/UStealth.WinUI/App.xaml.cs
@@ -1,21 +1,6 @@
 ﻿using DevWinUI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
-using Microsoft.UI.Xaml.Shapes;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.ApplicationModel;
-using Windows.ApplicationModel.Activation;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.

--- a/UStealth.WinUI/App.xaml.cs
+++ b/UStealth.WinUI/App.xaml.cs
@@ -16,7 +16,7 @@ namespace UStealth.WinUI
         public Frame RootFrame { get; set; }
         public new static App Current => (App)Application.Current;
         public IThemeService ThemeService { get; set; }
-        public BackdropType AppBackdrop { get; set; }
+        public BackdropType AppBackdrop { get; set; } = BackdropType.Mica;
 
         /// <summary>
         /// Initializes the singleton application object.  This is the first line of authored code

--- a/UStealth.WinUI/MainWindow.xaml.cs
+++ b/UStealth.WinUI/MainWindow.xaml.cs
@@ -4,6 +4,8 @@ using Microsoft.UI.Xaml.Navigation;
 using System;
 using DevWinUI;
 using UStealth.WinUI.Pages;
+using Microsoft.UI.Windowing;
+using Windows.Graphics;
 
 namespace UStealth.WinUI
 {
@@ -20,6 +22,7 @@ namespace UStealth.WinUI
         {
             Current = this;
             InitializeComponent();
+            ApplySavedWindowSize();
             GetNavigationStyle();
             ExtendsContentIntoTitleBar = true;
             AppIcon.ImageSource = AppIconUri;
@@ -76,6 +79,17 @@ namespace UStealth.WinUI
                 "Auto" => NavigationViewPaneDisplayMode.Auto,
                 _ => NavigationViewPaneDisplayMode.Top
             };
+        }
+
+        private void ApplySavedWindowSize()
+        {
+            var sizeString = Windows.Storage.ApplicationData.Current.LocalSettings.Values["WindowSize"] as string;
+            if (string.IsNullOrEmpty(sizeString)) return;
+            var parts = sizeString.Split(',');
+            if (parts.Length == 2 && int.TryParse(parts[0], out int width) && int.TryParse(parts[1], out int height))
+            {
+                this.AppWindow.Resize(new SizeInt32(width, height));
+            }
         }
     }
 }

--- a/UStealth.WinUI/MainWindow.xaml.cs
+++ b/UStealth.WinUI/MainWindow.xaml.cs
@@ -18,10 +18,13 @@ namespace UStealth.WinUI
         public Microsoft.UI.Xaml.Media.Imaging.BitmapImage AppIconUri => new(new Uri("ms-appx:///Assets/StoreLogo.png"));
         public  NavigationViewPaneDisplayMode NavigationStyle { get; set; }
 
+        public SizeInt32 DefaultWinUiSize { get; set; }
+
         public MainWindow()
         {
             Current = this;
             InitializeComponent();
+            DefaultWinUiSize = AppWindow.Size;
             ApplySavedWindowSize();
             GetNavigationStyle();
             ExtendsContentIntoTitleBar = true;

--- a/UStealth.WinUI/Pages/SettingsPage.xaml
+++ b/UStealth.WinUI/Pages/SettingsPage.xaml
@@ -127,7 +127,8 @@
                             Minimum="500"
                             SmallChange="10"
                             StepFrequency="10"
-                            ValueChanged="WindowHeightSlider_ValueChanged" />
+                            ValueChanged="WindowHeightSlider_ValueChanged"
+                            Value="{x:Bind AppHeight}" />
                     </devWinUi:SettingsCard>
                     <!--  Width Card  -->
                     <devWinUi:SettingsCard
@@ -147,7 +148,8 @@
                             Minimum="500"
                             SmallChange="10"
                             StepFrequency="10"
-                            ValueChanged="WindowWidthSlider_ValueChanged" />
+                            ValueChanged="WindowWidthSlider_ValueChanged"
+                            Value="{x:Bind AppWidth}" />
                     </devWinUi:SettingsCard>
                 </devWinUi:SettingsExpander.Items>
             </devWinUi:SettingsExpander>

--- a/UStealth.WinUI/Pages/SettingsPage.xaml
+++ b/UStealth.WinUI/Pages/SettingsPage.xaml
@@ -121,12 +121,13 @@
                         </devWinUi:SettingsCard.HeaderIcon>
 
                         <Slider
+                            x:Name="WindowHeightSlider"
                             Width="200"
                             Maximum="{x:Bind MaximumHeight}"
                             Minimum="500"
                             SmallChange="10"
                             StepFrequency="10"
-                            Value="790" />
+                            ValueChanged="WindowHeightSlider_ValueChanged" />
                     </devWinUi:SettingsCard>
                     <!--  Width Card  -->
                     <devWinUi:SettingsCard
@@ -140,12 +141,13 @@
                         </devWinUi:SettingsCard.HeaderIcon>
 
                         <Slider
+                            x:Name="WindowWidthSlider"
                             Width="200"
                             Maximum="{x:Bind MaximumWidth}"
                             Minimum="500"
                             SmallChange="10"
                             StepFrequency="10"
-                            Value="790" />
+                            ValueChanged="WindowWidthSlider_ValueChanged" />
                     </devWinUi:SettingsCard>
                 </devWinUi:SettingsExpander.Items>
             </devWinUi:SettingsExpander>

--- a/UStealth.WinUI/Pages/SettingsPage.xaml
+++ b/UStealth.WinUI/Pages/SettingsPage.xaml
@@ -22,138 +22,140 @@
             FontSize="36"
             FontWeight="Bold"
             Text="Settings" />
-        <StackPanel
-            Grid.Row="1"
-            Margin="0,32,0,0"
-            Spacing="32">
-            <!--  Appearance & behavior section  -->
-            <devWinUi:SettingsExpander
-                Margin="16,0"
-                Background="Transparent"
-                Description="Settings that modify the appearance and behaviour of the app"
-                Header="Appearance &amp; behavior">
-                <devWinUi:SettingsExpander.Items>
-                    <!--  App theme Card  -->
-                    <devWinUi:SettingsCard
-                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                        CornerRadius="8"
-                        Description="Select which app theme to display"
-                        Header="App Theme"
-                        IsClickEnabled="False">
-                        <devWinUi:SettingsCard.HeaderIcon>
-                            <FontIcon Glyph="&#xE790;" />
-                        </devWinUi:SettingsCard.HeaderIcon>
-                        <ComboBox
-                            x:Name="ThemeComboBox"
-                            Width="100"
-                            HorizontalAlignment="Right"
-                            SelectionChanged="OnThemeChanged">
-                            <ComboBoxItem Content="Light" Tag="Light" />
-                            <ComboBoxItem Content="Dark" Tag="Dark" />
-                            <ComboBoxItem Content="System" Tag="Default" />
-                        </ComboBox>
-                    </devWinUi:SettingsCard>
-                    <!--  Backdrop Card  -->
-                    <devWinUi:SettingsCard
-                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                        CornerRadius="8"
-                        Description="Select which app theme to display"
-                        Header="App Backdrop"
-                        IsClickEnabled="False">
-                        <devWinUi:SettingsCard.HeaderIcon>
-                            <FontIcon Glyph="&#xEF1F;" />
-                        </devWinUi:SettingsCard.HeaderIcon>
-                        <ComboBox
-                            x:Name="BackdropComboBox"
-                            Width="100"
-                            HorizontalAlignment="Right"
-                            SelectedValuePath="Tag"
-                            SelectionChanged="BackdropComboBox_OnSelectionChanged">
-                            <ComboBoxItem Content="None" Tag="None" />
-                            <ComboBoxItem Content="Mica" Tag="Mica" />
-                            <ComboBoxItem Content="Mica Alt" Tag="MicaAlt" />
-                            <ComboBoxItem Content="Acrylic" Tag="Acrylic" />
-                            <ComboBoxItem Content="Acrylic Thin" Tag="AcrylicThin" />
-                            <ComboBoxItem Content="Transparent" Tag="Transparent" />
-                        </ComboBox>
-                    </devWinUi:SettingsCard>
-                    <!--  Navigation Style Card  -->
-                    <devWinUi:SettingsCard
-                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                        CornerRadius="8"
-                        Description="Choose how navigation is displayed"
-                        Header="Navigation Style"
-                        IsClickEnabled="False">
-                        <devWinUi:SettingsCard.HeaderIcon>
-                            <FontIcon FontFamily="Segoe MDL2 Assets " Glyph="&#xE8A7;" />
-                        </devWinUi:SettingsCard.HeaderIcon>
-                        <ComboBox
-                            x:Name="NavigationStyleComboBox"
-                            Width="100"
-                            HorizontalAlignment="Right"
-                            SelectedValuePath="Tag"
-                            SelectionChanged="NavigationStyleComboBox_OnSelectionChanged">
-                            <ComboBoxItem Content="Top" Tag="Top" />
-                            <ComboBoxItem Content="Left" Tag="Left" />
-                            <ComboBoxItem Content="Left Compact" Tag="Left Compact" />
-                            <ComboBoxItem Content="Left Minimal" Tag="Left Minimal" />
-                            <ComboBoxItem Content="Left Auto" Tag="Left Auto" />
-                        </ComboBox>
-                    </devWinUi:SettingsCard>
-                </devWinUi:SettingsExpander.Items>
-            </devWinUi:SettingsExpander>
-            <!--  Windowing section  -->
-            <devWinUi:SettingsExpander
-                Margin="16,0"
-                Background="Transparent"
-                Description="Settings that modify the window behaviour of the app"
-                Header="Windowing">
-                <Button Content="Reset to Default" Click="ResetSize_OnClick" />
-                <devWinUi:SettingsExpander.Items>
-                    <!--  Height Card  -->
-                    <devWinUi:SettingsCard
-                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                        CornerRadius="8"
-                        Description="Customize the default Window Height"
-                        Header="Window Height"
-                        IsClickEnabled="False">
-                        <devWinUi:SettingsCard.HeaderIcon>
-                            <FontIcon Glyph="&#xE7EB;" />
-                        </devWinUi:SettingsCard.HeaderIcon>
+        <ScrollView Grid.Row="1">
+            <StackPanel
+                Grid.Row="1"
+                Margin="0,32,0,0"
+                Spacing="32">
+                <!--  Appearance & behavior section  -->
+                <devWinUi:SettingsExpander
+                    Margin="16,0"
+                    Background="Transparent"
+                    Description="Settings that modify the appearance and behaviour of the app"
+                    Header="Appearance &amp; behavior">
+                    <devWinUi:SettingsExpander.Items>
+                        <!--  App theme Card  -->
+                        <devWinUi:SettingsCard
+                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Description="Select which app theme to display"
+                            Header="App Theme"
+                            IsClickEnabled="False">
+                            <devWinUi:SettingsCard.HeaderIcon>
+                                <FontIcon Glyph="&#xE790;" />
+                            </devWinUi:SettingsCard.HeaderIcon>
+                            <ComboBox
+                                x:Name="ThemeComboBox"
+                                Width="100"
+                                HorizontalAlignment="Right"
+                                SelectionChanged="OnThemeChanged">
+                                <ComboBoxItem Content="Light" Tag="Light" />
+                                <ComboBoxItem Content="Dark" Tag="Dark" />
+                                <ComboBoxItem Content="System" Tag="Default" />
+                            </ComboBox>
+                        </devWinUi:SettingsCard>
+                        <!--  Backdrop Card  -->
+                        <devWinUi:SettingsCard
+                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Description="Select which app theme to display"
+                            Header="App Backdrop"
+                            IsClickEnabled="False">
+                            <devWinUi:SettingsCard.HeaderIcon>
+                                <FontIcon Glyph="&#xEF1F;" />
+                            </devWinUi:SettingsCard.HeaderIcon>
+                            <ComboBox
+                                x:Name="BackdropComboBox"
+                                Width="100"
+                                HorizontalAlignment="Right"
+                                SelectedValuePath="Tag"
+                                SelectionChanged="BackdropComboBox_OnSelectionChanged">
+                                <ComboBoxItem Content="None" Tag="None" />
+                                <ComboBoxItem Content="Mica" Tag="Mica" />
+                                <ComboBoxItem Content="Mica Alt" Tag="MicaAlt" />
+                                <ComboBoxItem Content="Acrylic" Tag="Acrylic" />
+                                <ComboBoxItem Content="Acrylic Thin" Tag="AcrylicThin" />
+                                <ComboBoxItem Content="Transparent" Tag="Transparent" />
+                            </ComboBox>
+                        </devWinUi:SettingsCard>
+                        <!--  Navigation Style Card  -->
+                        <devWinUi:SettingsCard
+                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Description="Choose how navigation is displayed"
+                            Header="Navigation Style"
+                            IsClickEnabled="False">
+                            <devWinUi:SettingsCard.HeaderIcon>
+                                <FontIcon FontFamily="Segoe MDL2 Assets " Glyph="&#xE8A7;" />
+                            </devWinUi:SettingsCard.HeaderIcon>
+                            <ComboBox
+                                x:Name="NavigationStyleComboBox"
+                                Width="100"
+                                HorizontalAlignment="Right"
+                                SelectedValuePath="Tag"
+                                SelectionChanged="NavigationStyleComboBox_OnSelectionChanged">
+                                <ComboBoxItem Content="Top" Tag="Top" />
+                                <ComboBoxItem Content="Left" Tag="Left" />
+                                <ComboBoxItem Content="Left Compact" Tag="Left Compact" />
+                                <ComboBoxItem Content="Left Minimal" Tag="Left Minimal" />
+                                <ComboBoxItem Content="Left Auto" Tag="Left Auto" />
+                            </ComboBox>
+                        </devWinUi:SettingsCard>
+                    </devWinUi:SettingsExpander.Items>
+                </devWinUi:SettingsExpander>
+                <!--  Windowing section  -->
+                <devWinUi:SettingsExpander
+                    Margin="16,0"
+                    Background="Transparent"
+                    Description="Settings that modify the window behaviour of the app"
+                    Header="Windowing">
+                    <Button Click="ResetSize_OnClick" Content="Reset to Default" />
+                    <devWinUi:SettingsExpander.Items>
+                        <!--  Height Card  -->
+                        <devWinUi:SettingsCard
+                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Description="Customize the default Window Height"
+                            Header="Window Height"
+                            IsClickEnabled="False">
+                            <devWinUi:SettingsCard.HeaderIcon>
+                                <FontIcon Glyph="&#xE7EB;" />
+                            </devWinUi:SettingsCard.HeaderIcon>
 
-                        <Slider
-                            x:Name="WindowHeightSlider"
-                            Width="200"
-                            Maximum="{x:Bind MaximumHeight}"
-                            Minimum="500"
-                            SmallChange="10"
-                            StepFrequency="10"
-                            ValueChanged="WindowHeightSlider_ValueChanged"
-                            Value="{x:Bind AppHeight}" />
-                    </devWinUi:SettingsCard>
-                    <!--  Width Card  -->
-                    <devWinUi:SettingsCard
-                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                        CornerRadius="8"
-                        Description="Customize the default Window Width"
-                        Header="Window Width"
-                        IsClickEnabled="False">
-                        <devWinUi:SettingsCard.HeaderIcon>
-                            <FontIcon Glyph="&#xEA62;" />
-                        </devWinUi:SettingsCard.HeaderIcon>
+                            <Slider
+                                x:Name="WindowHeightSlider"
+                                Width="200"
+                                Maximum="{x:Bind MaximumHeight}"
+                                Minimum="500"
+                                SmallChange="10"
+                                StepFrequency="10"
+                                ValueChanged="WindowHeightSlider_ValueChanged"
+                                Value="{x:Bind AppHeight}" />
+                        </devWinUi:SettingsCard>
+                        <!--  Width Card  -->
+                        <devWinUi:SettingsCard
+                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            CornerRadius="8"
+                            Description="Customize the default Window Width"
+                            Header="Window Width"
+                            IsClickEnabled="False">
+                            <devWinUi:SettingsCard.HeaderIcon>
+                                <FontIcon Glyph="&#xEA62;" />
+                            </devWinUi:SettingsCard.HeaderIcon>
 
-                        <Slider
-                            x:Name="WindowWidthSlider"
-                            Width="200"
-                            Maximum="{x:Bind MaximumWidth}"
-                            Minimum="500"
-                            SmallChange="10"
-                            StepFrequency="10"
-                            ValueChanged="WindowWidthSlider_ValueChanged"
-                            Value="{x:Bind AppWidth}" />
-                    </devWinUi:SettingsCard>
-                </devWinUi:SettingsExpander.Items>
-            </devWinUi:SettingsExpander>
-        </StackPanel>
+                            <Slider
+                                x:Name="WindowWidthSlider"
+                                Width="200"
+                                Maximum="{x:Bind MaximumWidth}"
+                                Minimum="500"
+                                SmallChange="10"
+                                StepFrequency="10"
+                                ValueChanged="WindowWidthSlider_ValueChanged"
+                                Value="{x:Bind AppWidth}" />
+                        </devWinUi:SettingsCard>
+                    </devWinUi:SettingsExpander.Items>
+                </devWinUi:SettingsExpander>
+            </StackPanel>
+        </ScrollView>
     </Grid>
 </Page>

--- a/UStealth.WinUI/Pages/SettingsPage.xaml
+++ b/UStealth.WinUI/Pages/SettingsPage.xaml
@@ -108,6 +108,7 @@
                 Background="Transparent"
                 Description="Settings that modify the window behaviour of the app"
                 Header="Windowing">
+                <Button Content="Reset to Default" Click="ResetSize_OnClick" />
                 <devWinUi:SettingsExpander.Items>
                     <!--  Height Card  -->
                     <devWinUi:SettingsCard

--- a/UStealth.WinUI/Pages/SettingsPage.xaml
+++ b/UStealth.WinUI/Pages/SettingsPage.xaml
@@ -28,11 +28,10 @@
             Spacing="32">
             <!--  Appearance & behavior section  -->
             <devWinUi:SettingsExpander
-                Margin="16"
+                Margin="16,0"
                 Background="Transparent"
                 Description="Settings that modify the appearance and behaviour of the app"
-                Header="Appearance &amp; behavior"
-                IsExpanded="true">
+                Header="Appearance &amp; behavior">
                 <devWinUi:SettingsExpander.Items>
                     <!--  App theme Card  -->
                     <devWinUi:SettingsCard
@@ -100,6 +99,53 @@
                             <ComboBoxItem Content="Left Minimal" Tag="Left Minimal" />
                             <ComboBoxItem Content="Left Auto" Tag="Left Auto" />
                         </ComboBox>
+                    </devWinUi:SettingsCard>
+                </devWinUi:SettingsExpander.Items>
+            </devWinUi:SettingsExpander>
+            <!--  Windowing section  -->
+            <devWinUi:SettingsExpander
+                Margin="16,0"
+                Background="Transparent"
+                Description="Settings that modify the window behaviour of the app"
+                Header="Windowing">
+                <devWinUi:SettingsExpander.Items>
+                    <!--  Height Card  -->
+                    <devWinUi:SettingsCard
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        CornerRadius="8"
+                        Description="Customize the default Window Height"
+                        Header="Window Height"
+                        IsClickEnabled="False">
+                        <devWinUi:SettingsCard.HeaderIcon>
+                            <FontIcon Glyph="&#xE7EB;" />
+                        </devWinUi:SettingsCard.HeaderIcon>
+
+                        <Slider
+                            Width="200"
+                            Maximum="{x:Bind MaximumHeight}"
+                            Minimum="500"
+                            SmallChange="10"
+                            StepFrequency="10"
+                            Value="790" />
+                    </devWinUi:SettingsCard>
+                    <!--  Width Card  -->
+                    <devWinUi:SettingsCard
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        CornerRadius="8"
+                        Description="Customize the default Window Width"
+                        Header="Window Width"
+                        IsClickEnabled="False">
+                        <devWinUi:SettingsCard.HeaderIcon>
+                            <FontIcon Glyph="&#xEA62;" />
+                        </devWinUi:SettingsCard.HeaderIcon>
+
+                        <Slider
+                            Width="200"
+                            Maximum="{x:Bind MaximumWidth}"
+                            Minimum="500"
+                            SmallChange="10"
+                            StepFrequency="10"
+                            Value="790" />
                     </devWinUi:SettingsCard>
                 </devWinUi:SettingsExpander.Items>
             </devWinUi:SettingsExpander>

--- a/UStealth.WinUI/Pages/SettingsPage.xaml.cs
+++ b/UStealth.WinUI/Pages/SettingsPage.xaml.cs
@@ -159,13 +159,13 @@ namespace UStealth.WinUI.Pages
         {
             var appWindow = MainWindow.Current?.AppWindow;
             var displayArea = DisplayArea.GetFromWindowId(appWindow.Id, DisplayAreaFallback.Primary);
-            return displayArea.WorkArea; // or displayArea.Bounds for the full screen
+            return displayArea.OuterBounds; // Use Bounds for full screen size
         }
 
         private void ResetSize_OnClick(object sender, RoutedEventArgs e)
         {
             Windows.Storage.ApplicationData.Current.LocalSettings.Values.Remove("WindowSize");
-            var height = MaximumHeight * 0.70;
+            var height = MaximumHeight * 0.69;
             var width = MaximumWidth * 0.75;
             WindowHeightSlider.Value = height;
             WindowWidthSlider.Value = width;

--- a/UStealth.WinUI/Pages/SettingsPage.xaml.cs
+++ b/UStealth.WinUI/Pages/SettingsPage.xaml.cs
@@ -1,10 +1,14 @@
-using System;
+using DevWinUI;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.Windows.Storage;
+using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using DevWinUI;
-using Microsoft.UI.Xaml;
-using Microsoft.Windows.Storage;
+using Windows.Foundation;
+using Windows.Graphics;
 //using Microsoft.UI.Xaml;
 
 // To learn more about WinUI, the WinUI project structure,
@@ -18,6 +22,11 @@ namespace UStealth.WinUI.Pages
     public sealed partial class SettingsPage : Page
     {
         private ComboBox _themeComboBox;
+        private double MaximumHeight { get; set; } = GetScreenResolution().Height;
+
+        private double MaximumWidth { get; set; } = GetScreenResolution().Width;
+
+
 
         public SettingsPage()
         {
@@ -124,6 +133,13 @@ namespace UStealth.WinUI.Pages
             {
                 await ShowDialog("Error", ex.Message);
             }
+        }
+
+        private static RectInt32 GetScreenResolution()
+        {
+            var appWindow = MainWindow.Current?.AppWindow;
+            var displayArea = DisplayArea.GetFromWindowId(appWindow.Id, DisplayAreaFallback.Primary);
+            return displayArea.WorkArea; // or displayArea.Bounds for the full screen
         }
     }
 }

--- a/UStealth.WinUI/Pages/SettingsPage.xaml.cs
+++ b/UStealth.WinUI/Pages/SettingsPage.xaml.cs
@@ -2,6 +2,7 @@ using DevWinUI;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.Windows.Storage;
 using System;
 using System.Collections.Generic;
@@ -22,18 +23,14 @@ namespace UStealth.WinUI.Pages
     public sealed partial class SettingsPage : Page
     {
         private ComboBox _themeComboBox;
-        private double MaximumHeight { get; set; } = GetScreenResolution().Height;
-
-        private double MaximumWidth { get; set; } = GetScreenResolution().Width;
-
-
+        private double MaximumHeight { get; } = GetScreenResolution().Height;
+        private double MaximumWidth { get;} = GetScreenResolution().Width;
 
         public SettingsPage()
         {
             InitializeComponent();
             Page_Loaded();
         }
-
 
         private void Page_Loaded()
         {
@@ -57,6 +54,10 @@ namespace UStealth.WinUI.Pages
                 BackdropType.Transparent => "Transparent",
                 _ => "Mica"
             };
+
+            
+            WindowWidthSlider.Value = MainWindow.Current.AppWindow.Size.Width;
+            WindowHeightSlider.Value = MainWindow.Current.AppWindow.Size.Height;
         }
 
 
@@ -133,6 +134,26 @@ namespace UStealth.WinUI.Pages
             {
                 await ShowDialog("Error", ex.Message);
             }
+        }
+
+        private void WindowHeightSlider_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
+        {
+            SaveWindowSize();
+        }
+
+        private void WindowWidthSlider_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
+        {
+            SaveWindowSize();
+        }
+
+        private void SaveWindowSize()
+        {
+            if (WindowWidthSlider == null || WindowHeightSlider == null)
+                return;
+
+            var width = (int)WindowWidthSlider.Value;
+            var height = (int)WindowHeightSlider.Value;
+            Windows.Storage.ApplicationData.Current.LocalSettings.Values["WindowSize"] = $"{width},{height}";
         }
 
         private static RectInt32 GetScreenResolution()

--- a/UStealth.WinUI/Pages/SettingsPage.xaml.cs
+++ b/UStealth.WinUI/Pages/SettingsPage.xaml.cs
@@ -25,6 +25,8 @@ namespace UStealth.WinUI.Pages
         private ComboBox _themeComboBox;
         private double MaximumHeight { get; } = GetScreenResolution().Height;
         private double MaximumWidth { get;} = GetScreenResolution().Width;
+        private double AppHeight { get; set; } = MainWindow.Current!.AppWindow.Size.Height;
+        private double AppWidth { get; set; } = MainWindow.Current!.AppWindow.Size.Width;
 
         public SettingsPage()
         {
@@ -54,10 +56,6 @@ namespace UStealth.WinUI.Pages
                 BackdropType.Transparent => "Transparent",
                 _ => "Mica"
             };
-
-            
-            WindowWidthSlider.Value = MainWindow.Current.AppWindow.Size.Width;
-            WindowHeightSlider.Value = MainWindow.Current.AppWindow.Size.Height;
         }
 
 
@@ -154,6 +152,7 @@ namespace UStealth.WinUI.Pages
             var width = (int)WindowWidthSlider.Value;
             var height = (int)WindowHeightSlider.Value;
             Windows.Storage.ApplicationData.Current.LocalSettings.Values["WindowSize"] = $"{width},{height}";
+            MainWindow.Current!.AppWindow.Resize(new SizeInt32(width,height));
         }
 
         private static RectInt32 GetScreenResolution()

--- a/UStealth.WinUI/Pages/SettingsPage.xaml.cs
+++ b/UStealth.WinUI/Pages/SettingsPage.xaml.cs
@@ -161,5 +161,14 @@ namespace UStealth.WinUI.Pages
             var displayArea = DisplayArea.GetFromWindowId(appWindow.Id, DisplayAreaFallback.Primary);
             return displayArea.WorkArea; // or displayArea.Bounds for the full screen
         }
+
+        private void ResetSize_OnClick(object sender, RoutedEventArgs e)
+        {
+            Windows.Storage.ApplicationData.Current.LocalSettings.Values.Remove("WindowSize");
+            var height = MaximumHeight * 0.70;
+            var width = MaximumWidth * 0.75;
+            WindowHeightSlider.Value = height;
+            WindowWidthSlider.Value = width;
+        }
     }
 }

--- a/UStealth.WinUI/Pages/SettingsPage.xaml.cs
+++ b/UStealth.WinUI/Pages/SettingsPage.xaml.cs
@@ -165,10 +165,8 @@ namespace UStealth.WinUI.Pages
         private void ResetSize_OnClick(object sender, RoutedEventArgs e)
         {
             Windows.Storage.ApplicationData.Current.LocalSettings.Values.Remove("WindowSize");
-            var height = MaximumHeight * 0.69;
-            var width = MaximumWidth * 0.75;
-            WindowHeightSlider.Value = height;
-            WindowWidthSlider.Value = width;
+            WindowHeightSlider.Value = MainWindow.Current.DefaultWinUiSize.Height;
+            WindowWidthSlider.Value = MainWindow.Current.DefaultWinUiSize.Width;
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature allowing users to customize and persist the main window size for the WinUI app. It adds UI controls in the Settings page for adjusting the window's width and height, saves the chosen size to local settings, and ensures the window restores to the saved or default size on startup. Additional minor improvements include code cleanup and UI enhancements.

**Window size customization and persistence:**

* Added sliders and a "Reset to Default" button in `SettingsPage.xaml` to let users adjust and reset the main window's width and height, with values bound to the current window size and limited to the screen resolution.
* Implemented logic in `SettingsPage.xaml.cs` to handle slider value changes, save the selected window size in local settings, and apply the size change immediately to the main window. Also added logic to reset the window size to its default. [[1]](diffhunk://#diff-86bf6bfe0fdb45ee6cb102e80438b32c4553b9e85c87f82d64aaaa59916349cbR26-L28) [[2]](diffhunk://#diff-86bf6bfe0fdb45ee6cb102e80438b32c4553b9e85c87f82d64aaaa59916349cbR136-R170)

**Window size restoration on startup:**

* Modified `MainWindow.xaml.cs` to read the saved window size from local settings and apply it when the app starts. The default window size is stored for reset functionality. [[1]](diffhunk://#diff-4f986e74e5e258530dd351c6506ffb690c1f9138a38fb807bdd3fc73c8cc33bdR21-R28) [[2]](diffhunk://#diff-4f986e74e5e258530dd351c6506ffb690c1f9138a38fb807bdd3fc73c8cc33bdR86-R96)

**UI and code improvements:**

* Wrapped the settings content in a `ScrollView` for better usability and updated margins for consistency in `SettingsPage.xaml`.
* Cleaned up unused usings and improved organization in both `App.xaml.cs` and `SettingsPage.xaml.cs`. [[1]](diffhunk://#diff-a7963e292d68e4e4387bbc2cbdcec94db787108e8f2921d5622401f0cf345e50L4-L18) [[2]](diffhunk://#diff-86bf6bfe0fdb45ee6cb102e80438b32c4553b9e85c87f82d64aaaa59916349cbL1-R12)