### PR TITLE
WinUI: Added app execution alias UStealthGUI

### DIFF
--- a/UStealth.WinUI/Package.appxmanifest
+++ b/UStealth.WinUI/Package.appxmanifest
@@ -4,6 +4,7 @@
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
@@ -42,6 +43,13 @@
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png"  Square71x71Logo="Assets\SmallTile.png" Square310x310Logo="Assets\LargeTile.png"/>
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
+      <Extensions>
+        <uap5:Extension Category="windows.appExecutionAlias">
+          <uap5:AppExecutionAlias>
+            <uap5:ExecutionAlias Alias="UStealthGUI.exe"/>
+          </uap5:AppExecutionAlias>
+        </uap5:Extension>
+    </Extensions>	
     </Application>
   </Applications>
 

--- a/UStealth.WinUI/Package.appxmanifest
+++ b/UStealth.WinUI/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="23610AlickolliSoftware.U-Stealth"
     Publisher="CN=5CECD841-CF4E-45AF-B443-573F4A3614A0"
-    Version="1.0.3.0" />
+    Version="1.0.4.0" />
 
   <mp:PhoneIdentity PhoneProductId="c7e5a6da-d685-4804-8078-1ada8bd90a16" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 


### PR DESCRIPTION
This pull request updates the application manifest for `UStealth.WinUI` to support launching the app via an execution alias and increments the app version. The most important changes are grouped below:

**App Execution Alias Support:**

* Added a new `uap5:Extension` for `windows.appExecutionAlias` to the manifest, allowing the app to be launched using the `UStealthGUI.exe` alias from the command line. (`UStealth.WinUI/Package.appxmanifest`)

**Version Update:**

* Updated the app version from `1.0.3.0` to `1.0.4.0` in the manifest. (`UStealth.WinUI/Package.appxmanifest`)

**Manifest Schema Update:**

* Added the `xmlns:uap5` namespace to support the new app execution alias extension. (`UStealth.WinUI/Package.appxmanifest`)