### PR TITLE
[Windows App] native aot and trimming

### DIFF
--- a/UStealth.DriveHelper/Properties/PublishProfiles/win-arm64.pubxml
+++ b/UStealth.DriveHelper/Properties/PublishProfiles/win-arm64.pubxml
@@ -12,5 +12,6 @@
     <SelfContained>true</SelfContained>
     <PublishReadyToRun>false</PublishReadyToRun>
     <PublishSingleFile>true</PublishSingleFile>
+    <PublishAot>True</PublishAot>
   </PropertyGroup>
 </Project>

--- a/UStealth.DriveHelper/Properties/PublishProfiles/win-x64.pubxml
+++ b/UStealth.DriveHelper/Properties/PublishProfiles/win-x64.pubxml
@@ -12,5 +12,6 @@
     <SelfContained>true</SelfContained>
     <PublishReadyToRun>false</PublishReadyToRun>
     <PublishSingleFile>true</PublishSingleFile>
+    <PublishAot>True</PublishAot>
   </PropertyGroup>
 </Project>

--- a/UStealth.DriveHelper/Properties/PublishProfiles/win-x86.pubxml
+++ b/UStealth.DriveHelper/Properties/PublishProfiles/win-x86.pubxml
@@ -12,5 +12,6 @@
     <SelfContained>true</SelfContained>
     <PublishReadyToRun>false</PublishReadyToRun>
     <PublishSingleFile>true</PublishSingleFile>
+    <PublishAot>True</PublishAot>
   </PropertyGroup>
 </Project>

--- a/UStealth.DriveHelper/UStealth.DriveHelper.csproj
+++ b/UStealth.DriveHelper/UStealth.DriveHelper.csproj
@@ -12,7 +12,6 @@
     <Version>1.0.3.0</Version>
     <Nullable>enable</Nullable>
     <IsAotCompatible>true</IsAotCompatible>
-    <PublishAot>True</PublishAot>
     <PublishWmiLightStaticallyLinked>true</PublishWmiLightStaticallyLinked>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net9.0-windows' ">

--- a/UStealth.WinUI/Converters/StatusToColumnVisibilityConverters.cs
+++ b/UStealth.WinUI/Converters/StatusToColumnVisibilityConverters.cs
@@ -3,7 +3,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace UStealth.WinUI.Converters
 {
-    public class StatusToTemplateColumnVisibilityConverter : IValueConverter
+    public partial class StatusToTemplateColumnVisibilityConverter : IValueConverter
     {
         public object Convert(object value, System.Type targetType, object parameter, string language)
         {
@@ -17,7 +17,7 @@ namespace UStealth.WinUI.Converters
         }
     }
 
-    public class StatusToTextColumnVisibilityConverter : IValueConverter
+    public partial class StatusToTextColumnVisibilityConverter : IValueConverter
     {
         public object Convert(object value, System.Type targetType, object parameter, string language)
         {

--- a/UStealth.WinUI/Converters/StatusToIsOnConverter.cs
+++ b/UStealth.WinUI/Converters/StatusToIsOnConverter.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace UStealth.WinUI.Converters
 {
-    public class StatusToIsOnConverter : IValueConverter
+    public partial class StatusToIsOnConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {

--- a/UStealth.WinUI/Converters/UnknownStatusVisibilityConverter.cs
+++ b/UStealth.WinUI/Converters/UnknownStatusVisibilityConverter.cs
@@ -3,7 +3,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace UStealth.WinUI.Converters
 {
-    public class UnknownStatusVisibilityConverter : IValueConverter
+    public partial class UnknownStatusVisibilityConverter : IValueConverter
     {
         public object Convert(object value, System.Type targetType, object parameter, string language)
         {

--- a/UStealth.WinUI/Package.appxmanifest
+++ b/UStealth.WinUI/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="23610AlickolliSoftware.U-Stealth"
     Publisher="CN=5CECD841-CF4E-45AF-B443-573F4A3614A0"
-    Version="1.0.4.0" />
+    Version="1.0.5.0" />
 
   <mp:PhoneIdentity PhoneProductId="c7e5a6da-d685-4804-8078-1ada8bd90a16" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/UStealth.WinUI/Pages/MainPage.xaml
+++ b/UStealth.WinUI/Pages/MainPage.xaml
@@ -22,66 +22,82 @@
                 <FontIcon Glyph="&#xE72C;" />
             </Button>
         </StackPanel>
-        <tableView:TableView
-            x:Name="DrivesTableView"
-            Grid.Row="1"
-            Margin="0,16,0,0"
-            x:DataType="models:DriveInfoModel"
-            AutoGenerateColumns="False"
-            ItemsSource="{x:Bind Drives}"
-            SelectionMode="Single">
-            <tableView:TableView.Columns>
-                <tableView:TableViewCheckBoxColumn
-                    Binding="{Binding IsSystemDrive}"
-                    Header="System Drive"
-                    IsReadOnly="True" />
-                <tableView:TableViewTextColumn
-                    Binding="{Binding DriveLetter}"
-                    Header="Drive Letter"
-                    IsReadOnly="True" />
-                <tableView:TableViewTextColumn
-                    Width="80"
-                    Binding="{Binding Interface}"
-                    Header="Interface"
-                    IsReadOnly="True" />
-                <tableView:TableViewTextColumn
-                    Binding="{Binding VolumeLabel}"
-                    Header="Volume Label"
-                    IsReadOnly="True" />
-                <tableView:TableViewTextColumn
-                    Binding="{Binding Format}"
-                    Header="Format"
-                    IsReadOnly="True" />
-                <tableView:TableViewTextColumn
-                    Width="200"
-                    Binding="{Binding Model}"
-                    Header="Model"
-                    IsReadOnly="True" />
-                <tableView:TableViewTextColumn
-                    Binding="{Binding MediaType}"
-                    Header="Media type"
-                    IsReadOnly="True" />
-                <tableView:TableViewTextColumn
-                    Binding="{Binding Size}"
-                    Header="Size"
-                    IsReadOnly="True" />
-                <tableView:TableViewTemplateColumn x:Name="StatusTemplate" Header="Status">
-                    <tableView:TableViewTemplateColumn.CellTemplate>
-                        <DataTemplate>
-                            <StackPanel>
-                                <ToggleSwitch
-                                    x:Name="StatusToggle"
-                                    IsOn="{Binding Status, Mode=TwoWay, Converter={StaticResource StatusToIsOnConverter}}"
-                                    OffContent="NORMAL"
-                                    OnContent="HIDDEN"
-                                    Toggled="StatusToggle_OnToggled"
-                                    Visibility="{Binding Status, Converter={StaticResource StatusToTemplateColumnVisibilityConverter}}" />
-                                <TextBlock Text="{Binding Status}" Visibility="{Binding Status, Converter={StaticResource UnknownStatusVisibilityConverter}}" />
-                            </StackPanel>
-                        </DataTemplate>
-                    </tableView:TableViewTemplateColumn.CellTemplate>
-                </tableView:TableViewTemplateColumn>
-            </tableView:TableView.Columns>
-        </tableView:TableView>
+        <Grid Grid.Row="1">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock VerticalAlignment="Center" Text="Search here:" />
+                <TextBox
+                    x:Name="FilterText"
+                    Width="600"
+                    PlaceholderText="Search by any value from any of the columns"
+                    TextChanged="OnSearchTextChanged" />
+            </StackPanel>
+            <tableView:TableView
+                x:Name="DrivesTableView"
+                Grid.Row="1"
+                Margin="0,16,0,0"
+                x:DataType="models:DriveInfoModel"
+                AutoGenerateColumns="False"
+                CanFilterColumns="False"
+                ItemsSource="{x:Bind Drives}"
+                SelectionMode="Single">
+                <tableView:TableView.Columns>
+                    <tableView:TableViewCheckBoxColumn
+                        Binding="{Binding IsSystemDrive}"
+                        Header="System Drive"
+                        IsReadOnly="True" />
+                    <tableView:TableViewTextColumn
+                        Binding="{Binding DriveLetter}"
+                        Header="Drive Letter"
+                        IsReadOnly="True" />
+                    <tableView:TableViewTextColumn
+                        Width="80"
+                        Binding="{Binding Interface}"
+                        Header="Interface"
+                        IsReadOnly="True" />
+                    <tableView:TableViewTextColumn
+                        Binding="{Binding VolumeLabel}"
+                        Header="Volume Label"
+                        IsReadOnly="True" />
+                    <tableView:TableViewTextColumn
+                        Binding="{Binding Format}"
+                        Header="Format"
+                        IsReadOnly="True" />
+                    <tableView:TableViewTextColumn
+                        Width="200"
+                        Binding="{Binding Model}"
+                        Header="Model"
+                        IsReadOnly="True" />
+                    <tableView:TableViewTextColumn
+                        Binding="{Binding MediaType}"
+                        Header="Media type"
+                        IsReadOnly="True" />
+                    <tableView:TableViewTextColumn
+                        Binding="{Binding Size}"
+                        Header="Size"
+                        IsReadOnly="True" />
+                    <tableView:TableViewTemplateColumn x:Name="StatusTemplate" Header="Status">
+                        <tableView:TableViewTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <StackPanel>
+                                    <ToggleSwitch
+                                        x:Name="StatusToggle"
+                                        IsOn="{Binding Status, Mode=TwoWay, Converter={StaticResource StatusToIsOnConverter}}"
+                                        OffContent="NORMAL"
+                                        OnContent="HIDDEN"
+                                        Toggled="StatusToggle_OnToggled"
+                                        Visibility="{Binding Status, Converter={StaticResource StatusToTemplateColumnVisibilityConverter}}" />
+                                    <TextBlock Text="{Binding Status}" Visibility="{Binding Status, Converter={StaticResource UnknownStatusVisibilityConverter}}" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </tableView:TableViewTemplateColumn.CellTemplate>
+                    </tableView:TableViewTemplateColumn>
+                </tableView:TableView.Columns>
+            </tableView:TableView>
+        </Grid>
+
     </Grid>
 </Page>

--- a/UStealth.WinUI/Pages/MainPage.xaml
+++ b/UStealth.WinUI/Pages/MainPage.xaml
@@ -34,6 +34,11 @@
                     Width="600"
                     PlaceholderText="Search by any value from any of the columns"
                     TextChanged="OnSearchTextChanged" />
+                <CheckBox
+                    Checked="HideDrivesCheckBox_OnChecked"
+                    Content="Hide Fixed Drives"
+                    IsChecked="{x:Bind AreFixedDrivesHidden}"
+                    Unchecked="HideDrivesCheckBox_UnChecked" />
             </StackPanel>
             <tableView:TableView
                 x:Name="DrivesTableView"

--- a/UStealth.WinUI/UStealth.WinUI.csproj
+++ b/UStealth.WinUI/UStealth.WinUI.csproj
@@ -12,11 +12,8 @@
     <EnableMsixTooling>true</EnableMsixTooling>
     <Nullable>enable</Nullable>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <ItemGroup>
-    <None Remove="Pages\MainPage.xaml" />
-    <None Remove="SettingsPage.xaml" />
-  </ItemGroup>
 
   <ItemGroup>
     <Content Include="Assets\SplashScreen.scale-200.png" />
@@ -75,8 +72,6 @@
   <PropertyGroup>
     <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
     <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
-    <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
-    <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">False</PublishTrimmed>
     <PublishAot>True</PublishAot>
     <SelfContained>True</SelfContained>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>

--- a/UStealth.WinUI/UStealth.WinUI.csproj
+++ b/UStealth.WinUI/UStealth.WinUI.csproj
@@ -77,7 +77,7 @@
     <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
     <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">False</PublishTrimmed>
-    <PublishAot>False</PublishAot>
+    <PublishAot>True</PublishAot>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
     <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
     <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>

--- a/UStealth.WinUI/UStealth.WinUI.csproj
+++ b/UStealth.WinUI/UStealth.WinUI.csproj
@@ -78,6 +78,7 @@
     <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
     <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">False</PublishTrimmed>
     <PublishAot>True</PublishAot>
+    <SelfContained>True</SelfContained>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
     <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
     <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>

--- a/WinUI.TableView/Extensions/ObjectExtensions.cs
+++ b/WinUI.TableView/Extensions/ObjectExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;

--- a/WinUI.TableView/TableView.cs
+++ b/WinUI.TableView/TableView.cs
@@ -759,6 +759,24 @@ public partial class TableView : ListView
     }
 
     /// <summary>
+    /// Refreshes the items view of the TableView.
+    /// </summary>
+    public void RefreshView()
+    {
+        DeselectAll();
+        _collectionView.Refresh();
+    }
+
+    /// <summary>
+    /// Refreshes the sorting applied to the items in the TableView.
+    /// </summary>
+    public void RefreshSorting()
+    {
+        DeselectAll();
+        _collectionView.RefreshSorting();
+    }
+
+    /// <summary>
     /// Clears all sorting applied to the items.
     /// </summary>
     public void ClearAllSorting()

--- a/WinUI.TableView/TableViewRow.cs
+++ b/WinUI.TableView/TableViewRow.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using WinUI.TableView.Helpers;
-using WinRT;
 
 namespace WinUI.TableView;
 
@@ -18,7 +17,7 @@ namespace WinUI.TableView;
 /// </summary>
 
 #if WINDOWS
-[WinRT.GeneratedBindableCustomPropertyAttribute]
+[WinRT.GeneratedBindableCustomProperty]
 #endif
 public partial class TableViewRow : ListViewItem
 {

--- a/WinUI.TableView/WinUI.TableView.csproj
+++ b/WinUI.TableView/WinUI.TableView.csproj
@@ -8,6 +8,7 @@
     </TargetFrameworks> 
     <Nullable>enable</Nullable> 
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows'">

--- a/WinUI.TableView/WinUI.TableView.csproj
+++ b/WinUI.TableView/WinUI.TableView.csproj
@@ -7,6 +7,7 @@
       net9.0-windows10.0.19041.0;
     </TargetFrameworks> 
     <Nullable>enable</Nullable> 
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows'">
@@ -50,7 +51,6 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <Description>TableView/DataGrid control for WinUI.</Description>
     <PackageTags>WinUI, WinAppSDK, Windows, UNO, XAML, TableView, DataGrid</PackageTags>


### PR DESCRIPTION
This pull request introduces several improvements and new features to the UI and build configuration for the project. The most significant change is the addition of a search and filtering capability for drives in the main page, allowing users to search by any column value and optionally hide fixed drives. Additionally, the build process now enables Ahead-of-Time (AOT) compilation across multiple profiles, and several codebase enhancements were made for maintainability and performance.

**Main Page UI and Filtering Enhancements:**

* Added a search bar and "Hide Fixed Drives" checkbox to `MainPage.xaml`, allowing users to filter the displayed drives by any property and optionally hide fixed drives. Associated filter logic and state persistence were implemented in `MainPage.xaml.cs`. [[1]](diffhunk://#diff-73c2bedf825383dba6935f50baddac5abfbb4bc4a4566097ccae6ec117fc6ef1R25-R49) [[2]](diffhunk://#diff-7a5dfefab1d1b5b02767022b51ed777a57add3cdc0636d0c712824fe492ccd23R235-R327)
* Updated the drives table view to support custom filtering and disabled column filtering, improving usability and consistency with the new search features.

**Build and Publish Configuration Updates:**

* Enabled AOT compilation for all Windows publish profiles (`win-x64`, `win-x86`, `win-arm64`) and set `PublishAot` to `True` in both project files, ensuring better runtime performance and compatibility. [[1]](diffhunk://#diff-df0ff12c945358e667724ede052a54917f60bce80114c7b9f3a6160744c4af00R15) [[2]](diffhunk://#diff-cb19f832e9c510b3ac88d52bbdaaaceb648861a4943397e477bb47831dc4117aR15) [[3]](diffhunk://#diff-cd41b8f7d7a9c077dc902de91e97bad64fe9dea2eeb8e8761f2c439f839f29ffR15) [[4]](diffhunk://#diff-b04a548297c7e3ce7065fbed3a1b213645a6bed634bc7c89cc1ec118ae3331b8L78-R76)
* Removed redundant or misplaced `PublishAot` settings from `UStealth.DriveHelper.csproj` to centralize configuration.

**Codebase and Versioning Improvements:**

* Updated the app version in `Package.appxmanifest` from `1.0.4.0` to `1.0.5.0` to reflect new features and fixes.
* Changed converter classes in `Converters` to be `partial`, improving extensibility and maintainability. [[1]](diffhunk://#diff-97bac33095825f1553478c7641a4be569723225534e1295a477df050dde136ddL6-R6) [[2]](diffhunk://#diff-97bac33095825f1553478c7641a4be569723225534e1295a477df050dde136ddL20-R20) [[3]](diffhunk://#diff-426269f3c025a9a7aaaa5bb11ceab0e2994371485e82e4f2f21abe9e67a64f07L7-R7) [[4]](diffhunk://#diff-ba32df0af301bfef0d0a91d942b2663c3e87d8feb01c48ffdd52d65b1f694a43L6-R6)
* Refactored property access logic in `TableViewBoundColumn` to use compiled expressions for improved performance and reliability when accessing bound properties.

These changes collectively enhance the user experience, improve build performance, and streamline the codebase for future development.