### PR TITLE
Updated Windows App SDK to 1.8

### DIFF
--- a/UStealth.WinUI/App.xaml.cs
+++ b/UStealth.WinUI/App.xaml.cs
@@ -42,7 +42,7 @@ namespace UStealth.WinUI
             ThemeService.ConfigureBackdrop(AppBackdrop);
         }
 
-        public void SetApplicationTheme()
+        public async void SetApplicationTheme()
         {
             var theme = Windows.Storage.ApplicationData.Current.LocalSettings.Values["AppTheme"]?.ToString();
             if (theme != null)
@@ -50,19 +50,19 @@ namespace UStealth.WinUI
                 switch (theme)
                 {
                     case "Light":
-                        ThemeService.SetElementTheme(ElementTheme.Light);
+                        await ThemeService.SetElementThemeAsync(ElementTheme.Light);
                         break;
                     case "Dark":
-                        ThemeService.SetElementTheme(ElementTheme.Dark);
+                        await ThemeService.SetElementThemeAsync(ElementTheme.Dark);
                         break;
                     default:
-                        ThemeService.SetElementTheme(ElementTheme.Default);
+                        await ThemeService.SetElementThemeAsync(ElementTheme.Default);
                         break;
                 }
             }
             else
             {
-                ThemeService.SetElementTheme(ElementTheme.Default);
+                await ThemeService.SetElementThemeAsync(ElementTheme.Default);
             }
         }
 

--- a/UStealth.WinUI/Package.appxmanifest
+++ b/UStealth.WinUI/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="23610AlickolliSoftware.U-Stealth"
     Publisher="CN=5CECD841-CF4E-45AF-B443-573F4A3614A0"
-    Version="1.0.7.0" />
+    Version="1.0.8.0" />
 
   <mp:PhoneIdentity PhoneProductId="c7e5a6da-d685-4804-8078-1ada8bd90a16" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/UStealth.WinUI/UStealth.WinUI.csproj
+++ b/UStealth.WinUI/UStealth.WinUI.csproj
@@ -37,11 +37,11 @@
     <ProjectCapability Include="Msix" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DevWinUI" Version="8.9.2" />
-    <PackageReference Include="DevWinUI.Controls" Version="8.9.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4948" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.251107005" />
+    <PackageReference Include="DevWinUI" Version="9.9.2" />
+    <PackageReference Include="DevWinUI.Controls" Version="9.9.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7463" />
+    <PackageReference Include="Microsoft.WindowsAppSDK.WinUI" Version="1.8.250906003" />
     <PackageReference Include="WinUI.TableView" Version="1.3.4" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This pull request updates dependencies and improves theme setting logic in the application. The most significant changes include upgrading NuGet package versions, updating the app manifest version, and making the theme setting method asynchronous to better support awaiting theme changes.

**Dependency and version updates:**

* Upgraded several NuGet package references in `UStealth.WinUI.csproj`, including major version bumps for `DevWinUI`, `DevWinUI.Controls`, and `Microsoft.WindowsAppSDK` (now using `Microsoft.WindowsAppSDK.WinUI`), as well as minor updates for `Microsoft.Extensions.DependencyInjection.Abstractions` and `Microsoft.Windows.SDK.BuildTools`.
* Updated the application version in `Package.appxmanifest` from `1.0.7.0` to `1.0.8.0`.

**Theme management improvements:**

* Changed `SetApplicationTheme` in `App.xaml.cs` to be asynchronous and to use the new `SetElementThemeAsync` method, ensuring that theme changes are applied asynchronously and more reliably.